### PR TITLE
Add manual release update checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ DeepSeek Harness 搜番插件。在对话中搜索番剧，以可点击卡片展
 - 点击卡片后按字幕组和集数浏览资源
 - 支持复制磁力链接和打开 `.torrent` 文件
 - 可在 Harness 插件设置中启用来源、调整结果数量和站点地址
+- 在插件设置中查看当前版本，并手动检查 GitHub 正式 Release
 
 ## 环境要求
 
@@ -57,6 +58,7 @@ dsh plugin --profile web add /absolute/path/to/anime-find
 - **站点地址**：各来源的服务地址，可按需替换镜像
 
 保存后立即生效。配置会写入 Harness 用户目录下的 `anime-find.json`。
+版本与安装来源为只读信息，不会写入该配置文件。
 
 也可通过 `cordis.patch.yml` 设置默认来源：
 
@@ -71,6 +73,22 @@ dsh plugin --profile web add /absolute/path/to/anime-find
 启用某个来源后，插件会向对应站点发送搜索和详情请求。封面通过插件服务转发，配置仅保存在本机，不会写入仓库。
 
 请遵守来源站点的使用条款，并仅将下载能力用于你有权访问的内容。
+
+## 版本与更新
+
+在 **设置 → 插件 → 插件配置 → 搜番** 的「版本与更新」区块中，可手动检查
+GitHub 上的最新正式 Release。打开设置页不会自动检查，也不会使用预发布版或草稿
+Release。
+
+发现新版本时，「更新」按钮只会复制官方命令；请在终端执行后重启 `dsh web` 并强制
+刷新浏览器页面：
+
+```sh
+dsh plugin --profile web update anime-find
+```
+
+当前以 `link:` 或 `file:` 本地方式安装时，页面仍会显示版本对比，但不会提供该命令的
+复制入口。若仓库尚未发布正式 Release，检查结果会显示「暂无可用 Release，无法判断是否有更新」。
 
 ## 开发
 

--- a/src/client.js
+++ b/src/client.js
@@ -105,6 +105,30 @@ window.__ModuleLoader__.load({
 .af-cfg-save:disabled,.af-cfg-disc:disabled{opacity:.4;cursor:default}
 .af-cfg-disc{background:0 0;border:1px solid #d1d5db;color:#4b5563}
 .af-cfg-err{color:#b91c1c;flex:1;margin:0;font-size:12px}
+.af-version{border:1px solid var(--dsw-alias-border-l2,#e5e7eb);border-radius:10px;padding:14px;background:var(--dsw-alias-bg-layer-3,#fff)}
+.af-version-head{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;flex-wrap:wrap}
+.af-version-k{font-size:12px;color:var(--dsw-alias-label-tertiary,#6b7280);margin-bottom:3px}
+.af-version-v{font-size:20px;font-weight:650;font-variant-numeric:tabular-nums}
+.af-version-tag{display:inline-block;margin-top:6px;padding:3px 8px;border-radius:999px;background:var(--dsw-alias-bg-layer-2,#f3f4f6);color:var(--dsw-alias-label-caption,#6b7280);font-size:11px;max-width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.af-update-check,.af-update-copy{appearance:none;border-radius:8px;padding:6px 12px;font:inherit;font-size:13px;cursor:pointer}
+.af-update-check{border:1px solid #111827;background:#111827;color:#fff}
+.af-update-copy{border:1px solid #111827;background:#111827;color:#fff}
+.af-update-check:disabled{opacity:.55;cursor:wait}
+.af-update-status{margin-top:12px;padding:10px 12px;border-radius:8px;font-size:12px;line-height:1.5}
+.af-update-status.checking{background:#eef4ff;color:#0550ae}
+.af-update-status.upToDate{background:#eaf7ee;color:#1a7f37}
+.af-update-status.updateAvailable,.af-update-status.localInstallRestricted{background:#fff8e6;color:#9a6700}
+.af-update-status.noRelease{background:#f4f5f7;color:#4b5563}
+.af-update-status.failed{background:#ffebe9;color:#cf222e}
+.af-update-compare{display:grid;grid-template-columns:1fr auto 1fr;gap:8px;align-items:center;margin-top:12px}
+.af-update-pill{border:1px solid var(--dsw-alias-border-l2,#e5e7eb);border-radius:8px;padding:8px 10px;font-variant-numeric:tabular-nums}
+.af-update-pill span{display:block;font-size:11px;color:var(--dsw-alias-label-tertiary,#6b7280)}
+.af-update-pill strong{display:block;margin-top:2px;font-size:14px}
+.af-update-cmd-label{margin-top:12px;font-size:12px;color:var(--dsw-alias-label-tertiary,#6b7280)}
+.af-update-cmd{margin-top:5px;padding:10px 12px;border-radius:8px;background:#111827;color:#e5e7eb;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px;line-height:1.5;word-break:break-all}
+.af-update-actions{display:flex;align-items:center;gap:10px;margin-top:10px}
+.af-update-restart{margin:10px 0 0;color:var(--dsw-alias-label-tertiary,#6b7280);font-size:12px;line-height:1.5}
+@media (max-width:560px){.af-update-compare{grid-template-columns:1fr}.af-update-arrow{display:none}}
 `;
 
     const CSS_ID = "anime-find-style";
@@ -153,17 +177,23 @@ window.__ModuleLoader__.load({
 
     async function copyText(text) {
       try {
-        await navigator.clipboard.writeText(text);
-        return true;
-      } catch {
+        if (navigator.clipboard?.writeText) {
+          await navigator.clipboard.writeText(text);
+          return true;
+        }
+      } catch { /* use the legacy fallback */ }
+      try {
         const input = document.createElement("input");
         input.value = text;
+        input.setAttribute("readonly", "");
+        input.style.position = "fixed";
+        input.style.left = "-9999px";
         document.body.appendChild(input);
         input.select();
-        document.execCommand("copy");
+        const copied = document.execCommand("copy");
         document.body.removeChild(input);
-        return true;
-      }
+        return copied;
+      } catch { return false; }
     }
 
     function Toast({ text, onDone }) {
@@ -566,12 +596,60 @@ window.__ModuleLoader__.load({
       };
     }
 
+    function installSourceLabel(metadata) {
+      const source = metadata?.installSource;
+      if (source === "github") return `安装来源 · ${metadata.installReference || "github:cocofhu/anime-find"}`;
+      if (source === "local") return `安装来源 · ${metadata.installReference || "本地 link/file"}`;
+      return "安装来源 · 未识别";
+    }
+
+    function VersionBlock({ metadata, result, checking, onCheck, onCopy }) {
+      const currentVersion = metadata?.currentVersion || "—";
+      const status = checking ? "checking" : result?.status;
+      const showCompare = status === "updateAvailable" || status === "localInstallRestricted";
+      const showCommand = status === "updateAvailable";
+      return h("div", { className: "af-cfg-f" },
+        h("label", null, "版本与更新"),
+        h("div", { className: "af-version" },
+          h("div", { className: "af-version-head" },
+            h("div", null,
+              h("div", { className: "af-version-k" }, "当前版本"),
+              h("div", { className: "af-version-v" }, currentVersion),
+              h("span", { className: "af-version-tag", title: metadata?.installReference || "" }, installSourceLabel(metadata)),
+            ),
+            h("button", { type: "button", className: "af-update-check", disabled: checking, onClick: onCheck }, checking ? "检查中…" : "检查更新"),
+          ),
+          status ? h("div", { className: "af-update-status " + status, role: "status", "aria-live": "polite" },
+            checking ? "正在查询 GitHub 正式 Release…" : result?.message,
+          ) : null,
+          showCompare ? h("div", { className: "af-update-compare" },
+            h("div", { className: "af-update-pill" }, h("span", null, "本地"), h("strong", null, currentVersion)),
+            h("div", { className: "af-update-arrow", "aria-hidden": "true" }, "→"),
+            h("div", { className: "af-update-pill" }, h("span", null, "最新正式版"), h("strong", null, result.latestVersion || "—")),
+          ) : null,
+          showCommand ? [
+            h("div", { key: "label", className: "af-update-cmd-label" }, "官方更新命令（终端执行）"),
+            h("div", { key: "command", className: "af-update-cmd" }, result.updateCommand),
+            h("div", { key: "actions", className: "af-update-actions" },
+              h("button", { type: "button", className: "af-update-copy", onClick: () => onCopy(result.updateCommand) }, "更新"),
+            ),
+            h("p", { key: "restart", className: "af-update-restart" }, "在终端执行更新命令后，请重启 dsh web 并刷新页面，新版本才会生效。「更新」按钮仅复制命令，不会自动安装。"),
+          ] : status === "localInstallRestricted" ? h("p", { className: "af-update-restart" }, "本地 link/file 安装请自行同步源码并重启 dsh web；请勿执行官方 update，以免破坏开发环境。") : null,
+        ),
+        h("p", { className: "af-cfg-hint" }, "仅在点击「检查更新」时查询 GitHub 正式 Release（忽略预发布与草稿）；不自动检查。"),
+      );
+    }
+
     function ConfigCard() {
       useEffect(() => ensureCss(), []);
       const [saved, setSaved] = useState(emptyDraft);
       const [draft, setDraft] = useState(emptyDraft);
       const [saving, setSaving] = useState(false);
       const [err, setErr] = useState("");
+      const [metadata, setMetadata] = useState(null);
+      const [updateResult, setUpdateResult] = useState(null);
+      const [checkingUpdate, setCheckingUpdate] = useState(false);
+      const [updateToast, setUpdateToast] = useState("");
       useEffect(() => {
         let live = true;
         api("config", {})
@@ -587,6 +665,12 @@ window.__ModuleLoader__.load({
             };
             setSaved(next);
             setDraft(next);
+            setMetadata({
+              currentVersion: d.currentVersion,
+              installSource: d.installSource,
+              installReference: d.installReference,
+              updateCommand: d.updateCommand,
+            });
           })
           .catch((e) => { if (live) setErr(e.message || String(e)); });
         return () => { live = false; };
@@ -620,6 +704,27 @@ window.__ModuleLoader__.load({
         } finally {
           setSaving(false);
         }
+      };
+      const checkUpdate = async () => {
+        if (checkingUpdate) return;
+        setCheckingUpdate(true);
+        setUpdateResult(null);
+        try {
+          const result = await api("checkUpdate", {});
+          setMetadata((current) => ({ ...current, ...result }));
+          setUpdateResult(result);
+        } catch {
+          setUpdateResult({
+            status: "failed",
+            message: "检查失败：无法连接 GitHub 或查询出错，请稍后重试。",
+          });
+        } finally {
+          setCheckingUpdate(false);
+        }
+      };
+      const copyUpdateCommand = async (command) => {
+        const copied = await copyText(command);
+        setUpdateToast(copied ? "已复制更新命令到剪贴板" : "复制失败，请手动复制上方命令");
       };
       return h("li", { className: "af-cfg-item" },
         h("details", { className: "af-cfg" },
@@ -687,6 +792,7 @@ window.__ModuleLoader__.load({
                 onChange: (e) => setDraft({ ...draft, gardenHost: e.target.value }),
               }),
             ),
+            h(VersionBlock, { metadata, result: updateResult, checking: checkingUpdate, onCheck: checkUpdate, onCopy: copyUpdateCommand }),
             h("div", { className: "af-cfg-ft" },
               err ? h("p", { className: "af-cfg-err" }, err) : null,
               h("button", { type: "button", className: "af-cfg-disc", disabled: !dirty || saving, onClick: () => setDraft(saved) }, "放弃修改"),
@@ -694,6 +800,7 @@ window.__ModuleLoader__.load({
             ),
           ),
         ),
+        updateToast ? h(Toast, { text: updateToast, onDone: () => setUpdateToast("") }) : null,
       );
     }
 

--- a/src/host.ts
+++ b/src/host.ts
@@ -7,6 +7,7 @@ import { fetchBytes } from './http.js'
 import { detailAnime, isSeasonBrowse, searchAnime } from './search.js'
 import { parseSeasonHint } from './season.js'
 import type { PluginConfig, SearchResult, SourceId } from './types.js'
+import { checkForUpdate, getVersionMetadata } from './update-check.js'
 
 export const name = 'anime-find'
 export const inject = ['tools']
@@ -186,7 +187,15 @@ async function handleApi(req: IncomingMessage, res: ServerResponse, cfg: PluginC
         assignConfig(cfg, sanitizePatch(body))
         writeOverlay(cfg)
       }
-      return sendJson(res, 200, { ok: true, ...publicConfig(cfg) })
+      return sendJson(res, 200, { ok: true, ...publicConfig(cfg), ...getVersionMetadata() })
+    }
+    if (method === 'checkUpdate') {
+      const metadata = getVersionMetadata()
+      const result = await checkForUpdate(metadata, {
+        timeoutMs: Math.min(cfg.timeoutMs, 15000),
+        userAgent: cfg.userAgent,
+      })
+      return sendJson(res, 200, { ok: true, ...result })
     }
     sendJson(res, 400, { ok: false, error: 'unknown method' })
   } catch (err) {

--- a/src/tests/update-check.test.ts
+++ b/src/tests/update-check.test.ts
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { HttpError } from '../http.js'
+import { checkForUpdate, classifyInstallSource, compareVersions, normalizeVersion } from '../update-check.js'
+
+const githubMetadata = {
+  currentVersion: '0.1.0',
+  installSource: 'github' as const,
+  installReference: 'github:cocofhu/anime-find',
+  updateCommand: 'dsh plugin --profile web update anime-find',
+}
+
+const localMetadata = {
+  ...githubMetadata,
+  installSource: 'local' as const,
+  installReference: 'link:/workspace/anime-find',
+}
+
+const options = { timeoutMs: 1000, userAgent: 'test' }
+
+test('normalizes and compares release versions', () => {
+  assert.equal(normalizeVersion('v1.2.3'), '1.2.3')
+  assert.equal(normalizeVersion('release-1.2.3'), undefined)
+  assert.ok(compareVersions('1.2.0', '1.1.9') > 0)
+  assert.ok(compareVersions('1.2.0', '1.2.1') < 0)
+  assert.equal(compareVersions('1.2.0', '1.2.0'), 0)
+})
+
+test('classifies GitHub and local install references', () => {
+  assert.equal(classifyInstallSource('github:cocofhu/anime-find'), 'github')
+  assert.equal(classifyInstallSource('link:/workspace/anime-find'), 'local')
+  assert.equal(classifyInstallSource('file:../anime-find'), 'local')
+  assert.equal(classifyInstallSource(undefined), 'unknown')
+})
+
+test('reports an available update for a GitHub install', async () => {
+  const result = await checkForUpdate(githubMetadata, options, async () => ({ tag_name: 'v0.2.0' }))
+  assert.equal(result.status, 'updateAvailable')
+  assert.equal(result.latestVersion, '0.2.0')
+})
+
+test('reports a restricted update for local installs', async () => {
+  const result = await checkForUpdate(localMetadata, options, async () => ({ tag_name: 'v0.2.0' }))
+  assert.equal(result.status, 'localInstallRestricted')
+  assert.equal(result.latestVersion, '0.2.0')
+})
+
+test('reports up to date when remote is equal or lower', async () => {
+  const result = await checkForUpdate(githubMetadata, options, async () => ({ tag_name: 'v0.1.0' }))
+  assert.equal(result.status, 'upToDate')
+})
+
+test('maps a missing latest release to noRelease', async () => {
+  const result = await checkForUpdate(githubMetadata, options, async () => {
+    throw new HttpError('not found', 404)
+  })
+  assert.equal(result.status, 'noRelease')
+})
+
+test('maps invalid releases and request failures without claiming up to date', async () => {
+  const invalid = await checkForUpdate(githubMetadata, options, async () => ({ tag_name: 'latest' }))
+  assert.equal(invalid.status, 'noRelease')
+  const failed = await checkForUpdate(githubMetadata, options, async () => {
+    throw new HttpError('server error', 500)
+  })
+  assert.equal(failed.status, 'failed')
+})

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -1,0 +1,121 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { fetchJson, HttpError } from './http.js'
+import type { FetchOptions } from './types.js'
+
+const require = createRequire(import.meta.url)
+const REPOSITORY = 'cocofhu/anime-find'
+const DEFAULT_PROFILE = process.env.DSH_PROFILE || 'web'
+
+export type InstallSource = 'github' | 'local' | 'unknown'
+export type UpdateStatus = 'upToDate' | 'updateAvailable' | 'noRelease' | 'failed' | 'localInstallRestricted'
+
+export interface VersionMetadata {
+  currentVersion: string
+  installSource: InstallSource
+  installReference?: string
+  updateCommand: string
+}
+
+export interface UpdateResult extends VersionMetadata {
+  status: UpdateStatus
+  latestVersion?: string
+  message: string
+}
+
+interface PackageJson {
+  version?: unknown
+  dependencies?: Record<string, unknown>
+}
+
+interface ReleaseResponse {
+  tag_name?: unknown
+}
+
+export function getVersionMetadata(profile = DEFAULT_PROFILE): VersionMetadata {
+  const ownPackage = require('../package.json') as PackageJson
+  const currentVersion = typeof ownPackage.version === 'string' ? ownPackage.version : '0.0.0'
+  const installReference = readInstallReference(profile)
+  const installSource = classifyInstallSource(installReference)
+  return {
+    currentVersion,
+    installSource,
+    ...(installReference ? { installReference } : {}),
+    updateCommand: `dsh plugin --profile ${profile} update anime-find`,
+  }
+}
+
+export async function checkForUpdate(
+  metadata: VersionMetadata,
+  options: FetchOptions,
+  getLatest: (url: string, options: FetchOptions) => Promise<ReleaseResponse> = fetchJson,
+): Promise<UpdateResult> {
+  try {
+    const release = await getLatest(`https://api.github.com/repos/${REPOSITORY}/releases/latest`, options)
+    const latestVersion = normalizeVersion(release.tag_name)
+    if (!latestVersion) return result(metadata, 'noRelease', '暂无可用 Release，无法判断是否有更新。')
+    if (compareVersions(latestVersion, metadata.currentVersion) <= 0) {
+      return result(metadata, 'upToDate', `已是最新版本（当前 ${metadata.currentVersion}）。`, latestVersion)
+    }
+    if (metadata.installSource !== 'github') {
+      return result(metadata, 'localInstallRestricted', '发现新正式版，但当前为本地或未知安装来源，请自行同步后重启。', latestVersion)
+    }
+    return result(metadata, 'updateAvailable', '发现新正式版，可按官方命令更新。', latestVersion)
+  } catch (err) {
+    if (err instanceof HttpError && err.status === 404) {
+      return result(metadata, 'noRelease', '暂无可用 Release，无法判断是否有更新。')
+    }
+    return result(metadata, 'failed', '检查失败：无法连接 GitHub 或查询出错，请稍后重试。')
+  }
+}
+
+export function normalizeVersion(value: unknown): string | undefined {
+  const normalized = String(value || '').trim().replace(/^v/i, '')
+  return /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(normalized) ? normalized : undefined
+}
+
+export function compareVersions(left: string, right: string): number {
+  const a = parseVersion(left)
+  const b = parseVersion(right)
+  if (!a || !b) return 0
+  for (let i = 0; i < 3; i += 1) {
+    if (a.parts[i] !== b.parts[i]) return a.parts[i] > b.parts[i] ? 1 : -1
+  }
+  if (a.pre === b.pre) return 0
+  if (!a.pre) return 1
+  if (!b.pre) return -1
+  return a.pre.localeCompare(b.pre, undefined, { numeric: true })
+}
+
+export function classifyInstallSource(reference?: string): InstallSource {
+  if (!reference) return 'unknown'
+  if (/^(github:|git\+https?:\/\/github\.com\/)/i.test(reference)) return 'github'
+  if (/^(link:|file:|\.{1,2}\/|\/)/i.test(reference)) return 'local'
+  return 'unknown'
+}
+
+function readInstallReference(profile: string): string | undefined {
+  const home = process.env.DSH_HOME || join(homedir(), '.dsh')
+  const path = join(home, 'profiles', profile, 'package.json')
+  if (!existsSync(path)) return undefined
+  try {
+    const pkg = JSON.parse(readFileSync(path, 'utf8')) as PackageJson
+    const value = pkg.dependencies?.['anime-find']
+    return typeof value === 'string' ? value : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function result(metadata: VersionMetadata, status: UpdateStatus, message: string, latestVersion?: string): UpdateResult {
+  return { ...metadata, status, ...(latestVersion ? { latestVersion } : {}), message }
+}
+
+function parseVersion(value: string): { parts: number[]; pre: string } | undefined {
+  const normalized = normalizeVersion(value)
+  if (!normalized) return undefined
+  const [core, suffix = ''] = normalized.split('-', 2)
+  return { parts: core.split('.').map(Number), pre: suffix.split('+', 1)[0] }
+}


### PR DESCRIPTION
Expose read-only plugin version metadata and guide users through the supported Harness update command without installing from the browser.

Co-authored-by: Cursor <cursoragent@cursor.com>
