### PR TITLE
Fix dark theme with Harness semantic tokens

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -6,36 +6,36 @@ window.__ModuleLoader__.load({
     const { useEffect, useMemo, useState } = React;
 
     const CSS = `
-.af-root{font-family:inherit;color:var(--dsw-alias-label-primary,inherit);max-width:920px}
-.af-hint{color:var(--dsw-alias-label-caption,#6b7280);font-size:12px;line-height:18px;margin:0 0 10px}
+.af-root{font-family:inherit;color:var(--dsw-alias-label-primary);max-width:920px}
+.af-hint{color:var(--dsw-alias-label-caption);font-size:12px;line-height:18px;margin:0 0 10px}
 .af-search{display:flex;gap:8px;margin-bottom:12px}
-.af-search input{flex:1;border:1px solid var(--dsw-alias-line-strong,#e5e7eb);border-radius:10px;padding:10px 12px;background:var(--dsw-alias-bg-primary,#fff);color:inherit;font:inherit}
-.af-search button,.af-mini{border:1px solid var(--dsw-alias-line-strong,#e5e7eb);background:var(--dsw-alias-bg-primary,#fff);border-radius:8px;padding:6px 10px;cursor:pointer;font:inherit;font-size:12px}
-.af-mini.primary{background:#111827;color:#fff;border-color:#111827}
+.af-search input{flex:1;border:1px solid var(--dsw-alias-border-l2);border-radius:10px;padding:10px 12px;background:var(--dsw-alias-bg-layer-2);color:var(--dsw-alias-label-primary);font:inherit}
+.af-search button,.af-mini{border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-button-elevated-fill);color:var(--dsw-alias-label-primary);border-radius:8px;padding:6px 10px;cursor:pointer;font:inherit;font-size:12px}
+.af-mini.primary{background:var(--dsw-alias-button-primary-fill);color:var(--dsw-alias-label-primary-foreground);border-color:transparent}
 .af-week{font-weight:700;font-size:13px;margin:8px 0 6px}
 .af-cards{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:10px}
 @media (max-width:720px){.af-cards{grid-template-columns:1fr}}
-.af-card{display:flex;gap:10px;align-items:stretch;background:var(--dsw-alias-bg-primary,#fff);border:1px solid var(--dsw-alias-line-strong,#e5e7eb);border-radius:12px;padding:10px;cursor:pointer;text-align:left;width:100%;font:inherit;color:inherit}
-.af-card:hover{border-color:#c7d2fe;box-shadow:0 4px 16px rgba(37,99,235,.12)}
+.af-card{display:flex;gap:10px;align-items:stretch;background:var(--dsw-alias-bg-layer-2);border:1px solid var(--dsw-alias-border-l1);border-radius:12px;padding:10px;cursor:pointer;text-align:left;width:100%;font:inherit;color:var(--dsw-alias-label-primary)}
+.af-card:hover{border-color:var(--dsw-alias-border-l2);background:var(--dsw-alias-interactive-bg-hover)}
 .af-card.busy{cursor:wait}
-.af-cover{width:72px;height:102px;border-radius:8px;object-fit:cover;border:1px solid var(--dsw-alias-line-strong,#e5e7eb);flex-shrink:0;background:#e5e7eb}
+.af-cover{width:72px;height:102px;border-radius:8px;object-fit:cover;border:1px solid var(--dsw-alias-border-l1);flex-shrink:0;background:var(--dsw-alias-bg-layer-3)}
 .af-meta{min-width:0;flex:1;display:flex;flex-direction:column;gap:4px}
-.af-title{font-weight:600;font-size:13px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-.af-score{color:#e800a4;font-weight:800;font-size:16px}
+.af-title{font-weight:600;font-size:13px;color:var(--dsw-alias-label-primary);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.af-score{color:var(--dsw-alias-state-business-primary);font-weight:800;font-size:16px}
 .af-tags{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:4px}
-.af-tag{font-size:11px;padding:2px 6px;border-radius:6px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;text-align:center;background:#f3f4f6;color:#4b5563}
-.af-tag.blue{background:#eff6ff;color:#1d4ed8}
-.af-tag.green{background:#ecfdf5;color:#047857}
-.af-tag.orange{background:#fff7ed;color:#c2410c}
-.af-tag.pink{background:#fdf2f8;color:#be185d}
-.af-ago{color:#6b7280;font-size:12px;margin-top:auto}
-.af-overlay{position:fixed;inset:0;z-index:2147483000;background:rgba(15,23,42,.48);display:flex;align-items:center;justify-content:center;padding:24px 16px;box-sizing:border-box}
-.af-drawer{position:relative;width:min(720px,100%);max-height:min(86vh,840px);margin:0 auto;background:var(--dsw-alias-bg-layer-1);border:1px solid var(--dsw-alias-border-l2);border-radius:12px;overflow:hidden;display:flex;flex-direction:column;box-shadow:0 18px 50px rgba(15,23,42,.28)}
-.af-close{position:absolute;top:10px;right:10px;width:32px;height:32px;border-radius:8px;border:1px solid #d1d5db;background:#fff;cursor:pointer;font-size:18px;line-height:1;color:#4b5563;z-index:2}
-.af-close:hover{background:#f3f4f6}
-.af-head{display:flex;gap:14px;align-items:flex-start;padding:18px 48px 16px 18px;border-bottom:1px solid #e5e7eb}
-.af-dcover{width:84px;height:118px;border-radius:8px;object-fit:cover;border:1px solid #e5e7eb;background:#e5e7eb;flex-shrink:0}
-.af-head h2{margin:0 0 6px;font-size:18px;line-height:1.35}
+.af-tag{font-size:11px;padding:2px 6px;border-radius:6px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;text-align:center;background:var(--dsw-alias-markdown-tag);color:var(--dsw-alias-label-secondary)}
+.af-tag.blue{background:light-dark(rgba(77,107,254,.10),rgba(125,147,255,.18));color:light-dark(rgb(58,85,217),rgb(174,187,255))}
+.af-tag.green{background:light-dark(rgba(16,163,106,.11),rgba(70,205,145,.16));color:light-dark(rgb(13,114,71),rgb(130,226,177))}
+.af-tag.orange{background:light-dark(rgba(234,138,20,.12),rgba(255,168,70,.16));color:light-dark(rgb(162,92,6),rgb(255,196,137))}
+.af-tag.pink{background:light-dark(rgba(226,62,128,.10),rgba(255,111,166,.16));color:light-dark(rgb(184,48,106),rgb(255,166,198))}
+.af-ago{color:var(--dsw-alias-label-tertiary);font-size:12px;margin-top:auto}
+.af-overlay{position:fixed;inset:0;z-index:2147483000;background:var(--dsw-alias-bg-mask-3);display:flex;align-items:center;justify-content:center;padding:24px 16px;box-sizing:border-box}
+.af-drawer{position:relative;width:min(720px,100%);max-height:min(86vh,840px);margin:0 auto;background:var(--dsw-alias-bg-layer-1);border:1px solid var(--dsw-alias-border-l2);border-radius:12px;overflow:hidden;display:flex;flex-direction:column}
+.af-close{position:absolute;top:10px;right:10px;width:32px;height:32px;border-radius:8px;border:1px solid var(--dsw-alias-border-l1);background:var(--dsw-alias-bg-layer-3);cursor:pointer;font-size:18px;line-height:1;color:var(--dsw-alias-label-secondary);z-index:2}
+.af-close:hover{background:var(--dsw-alias-interactive-bg-hover);color:var(--dsw-alias-label-primary);border-color:var(--dsw-alias-border-l2)}
+.af-head{display:flex;gap:14px;align-items:flex-start;padding:18px 48px 16px 18px;border-bottom:1px solid var(--dsw-alias-border-l1)}
+.af-dcover{width:84px;height:118px;border-radius:8px;object-fit:cover;border:1px solid var(--dsw-alias-border-l1);background:var(--dsw-alias-bg-layer-3);flex-shrink:0}
+.af-head h2{margin:0 0 6px;font-size:18px;line-height:1.35;color:var(--dsw-alias-label-primary)}
 .af-body{overflow:auto;padding:12px 18px 20px}
 .af-pills{display:flex;gap:8px;flex-wrap:wrap;margin:0 0 14px;justify-content:flex-start}
 .af-pill{font:inherit;font-size:12px;padding:5px 13px;border-radius:999px;border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-layer-1);color:var(--dsw-alias-label-caption);cursor:pointer;transition:background .16s ease,border-color .16s ease,color .16s ease}
@@ -67,11 +67,11 @@ window.__ModuleLoader__.load({
 .af-item .af-mini.primary{background:var(--dsw-alias-bg-layer-1);color:var(--dsw-alias-label-caption);border-color:var(--dsw-alias-border-l2)}
 .af-item .af-mini.ghost{border-color:transparent;background:transparent;color:var(--dsw-alias-brand-primary-new-colorprimary-new-color);padding:6px 8px}
 .af-item .af-mini.ghost:hover{background:var(--dsw-alias-button-ghost-active-fill)}
-.af-toast{position:fixed;left:50%;bottom:28px;transform:translateX(-50%);background:#111827;color:#fff;padding:10px 16px;border-radius:999px;font-size:13px;z-index:2147483646}
-.af-err{color:#b91c1c;font-size:12px;margin:8px 0}
+.af-toast{position:fixed;left:50%;bottom:28px;transform:translateX(-50%);background:var(--dsw-alias-toast-bg);color:var(--dsw-alias-label-primary-foreground);padding:10px 16px;border-radius:999px;font-size:13px;z-index:2147483646}
+.af-err{color:var(--dsw-alias-state-error-primary);font-size:12px;margin:8px 0}
 .af-tool{margin:4px 0 8px}
 .af-fade{animation:af-in .18s ease}
-.af-inflow{position:relative;width:100%;max-height:min(72vh,760px);margin:4px 0 8px;box-shadow:0 8px 24px rgba(15,23,42,.12)}
+.af-inflow{position:relative;width:100%;max-height:min(72vh,760px);margin:4px 0 8px}
 .af-load{display:flex;flex-direction:column;align-items:center;gap:14px;padding:28px 8px 12px;min-height:240px}
 .af-spin{width:28px;height:28px;border:3px solid var(--dsw-alias-bg-skeleton);border-top-color:var(--dsw-alias-brand-primary-new-colorprimary-new-color);border-radius:50%;animation:af-spin .7s linear infinite}
 .af-load-text{color:var(--dsw-alias-label-caption);font-size:13px}
@@ -81,30 +81,30 @@ window.__ModuleLoader__.load({
 @keyframes af-spin{to{transform:rotate(360deg)}}
 @keyframes af-shimmer{from{background-position:200% 0}to{background-position:-200% 0}}
 .af-cfg-item{list-style:none}
-.af-cfg{border:1px solid var(--dsw-alias-border-l2,#e5e7eb);background:var(--dsw-alias-bg-layer-3,#fff);border-radius:12px}
-.af-cfg[open]{background:var(--dsw-alias-bg-layer-2,#fafafa)}
+.af-cfg{border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-layer-3);border-radius:12px}
+.af-cfg[open]{background:var(--dsw-alias-bg-layer-2)}
 .af-cfg-h{display:block;cursor:pointer;list-style:none;padding:0}
 .af-cfg-h::-webkit-details-marker,.af-cfg-h::marker{display:none;content:none}
-.af-cfg-h-inner{appearance:none;width:100%;font:inherit;color:inherit;text-align:left;background:0 0;border:0;border-radius:12px;align-items:center;gap:12px;padding:14px 16px;display:flex}
+.af-cfg-h-inner{appearance:none;width:100%;font:inherit;color:var(--dsw-alias-label-primary);text-align:left;background:transparent;border:0;border-radius:12px;align-items:center;gap:12px;padding:14px 16px;display:flex}
 .af-cfg-t{flex-direction:column;flex:1;gap:4px;min-width:0;display:flex}
 .af-cfg-n{font-size:15px;font-weight:600;line-height:1.4}
-.af-cfg-d{color:var(--dsw-alias-label-tertiary,#6b7280);font-size:13px;line-height:1.5}
-.af-cfg-ch{color:var(--dsw-alias-label-tertiary,#6b7280);flex:none;width:14px;height:14px;transition:transform .16s;display:block;pointer-events:none}
+.af-cfg-d{color:var(--dsw-alias-label-tertiary);font-size:13px;line-height:1.5}
+.af-cfg-ch{color:var(--dsw-alias-label-tertiary);flex:none;width:14px;height:14px;transition:transform .16s;display:block;pointer-events:none}
 .af-cfg[open] .af-cfg-ch{transform:rotate(180deg)}
-.af-cfg-b{border-top:1px solid var(--dsw-alias-border-l2,#e5e7eb);margin:0 16px;padding:8px 0 12px}
-.af-cfg-f{display:flex;flex-direction:column;gap:6px;padding:10px 0;border-top:1px solid #eee}
+.af-cfg-b{border-top:1px solid var(--dsw-alias-border-l2);margin:0 16px;padding:8px 0 12px}
+.af-cfg-f{display:flex;flex-direction:column;gap:6px;padding:10px 0;border-top:1px solid var(--dsw-alias-border-l1)}
 .af-cfg-f:first-child{border-top:0}
-.af-cfg-f label{font-size:13px;font-weight:500}
-.af-cfg-f input[type=text],.af-cfg-f input[type=number]{border:1px solid var(--dsw-alias-border-l2,#e5e7eb);background:var(--dsw-alias-bg-layer-3,#fff);height:34px;font:inherit;border-radius:8px;padding:0 12px;font-size:13px}
-.af-cfg-hint{margin:0;color:#6b7280;font-size:12px}
+.af-cfg-f label{font-size:13px;font-weight:500;color:var(--dsw-alias-label-secondary)}
+.af-cfg-f input[type=text],.af-cfg-f input[type=number]{border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-layer-3);color:var(--dsw-alias-label-primary);height:34px;font:inherit;border-radius:8px;padding:0 12px;font-size:13px}
+.af-cfg-hint{margin:0;color:var(--dsw-alias-label-caption);font-size:12px}
 .af-cfg-src{display:flex;flex-wrap:wrap;gap:10px 16px}
 .af-cfg-src label{display:flex;gap:6px;align-items:center;font-weight:400;cursor:pointer}
-.af-cfg-ft{border-top:1px solid var(--dsw-alias-border-l2,#e5e7eb);justify-content:flex-end;gap:8px;padding:12px 0 4px;display:flex}
+.af-cfg-ft{border-top:1px solid var(--dsw-alias-border-l2);justify-content:flex-end;gap:8px;padding:12px 0 4px;display:flex}
 .af-cfg-ft button{appearance:none;font:inherit;cursor:pointer;border-radius:8px;padding:5px 14px;font-size:13px}
-.af-cfg-save{background:#111827;color:#fff;border:1px solid #111827}
+.af-cfg-save{background:var(--dsw-alias-button-primary-fill);color:var(--dsw-alias-label-primary-foreground);border:1px solid transparent}
 .af-cfg-save:disabled,.af-cfg-disc:disabled{opacity:.4;cursor:default}
-.af-cfg-disc{background:0 0;border:1px solid #d1d5db;color:#4b5563}
-.af-cfg-err{color:#b91c1c;flex:1;margin:0;font-size:12px}
+.af-cfg-disc{background:var(--dsw-alias-button-elevated-fill);border:1px solid var(--dsw-alias-border-l2);color:var(--dsw-alias-label-secondary)}
+.af-cfg-err{color:var(--dsw-alias-state-error-primary);flex:1;margin:0;font-size:12px}
 `;
 
     const CSS_ID = "anime-find-style";
@@ -128,10 +128,9 @@ window.__ModuleLoader__.load({
     } catch { /* overlay still works without portal */ }
 
     function placeholder(title) {
-      const t = encodeURIComponent(String(title || "番").slice(0, 6));
-      return `data:image/svg+xml,${encodeURIComponent(
-        `<svg xmlns="http://www.w3.org/2000/svg" width="180" height="260"><defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#c7d2fe"/><stop offset="1" stop-color="#fbcfe8"/></linearGradient></defs><rect width="100%" height="100%" fill="url(#g)"/><text x="50%" y="52%" text-anchor="middle" fill="#374151" font-size="18" font-family="sans-serif">${t}</text></svg>`,
-      )}`;
+      return "data:image/svg+xml," + encodeURIComponent(
+        '<svg xmlns="http://www.w3.org/2000/svg" width="180" height="260"></svg>',
+      );
     }
 
     function coverSrc(url, title) {

--- a/src/client.js
+++ b/src/client.js
@@ -24,10 +24,10 @@ window.__ModuleLoader__.load({
 .af-score{color:var(--dsw-alias-state-business-primary);font-weight:800;font-size:16px}
 .af-tags{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:4px}
 .af-tag{font-size:11px;padding:2px 6px;border-radius:6px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;text-align:center;background:var(--dsw-alias-markdown-tag);color:var(--dsw-alias-label-secondary)}
-.af-tag.blue{background:light-dark(rgba(77,107,254,.10),rgba(125,147,255,.18));color:light-dark(rgb(58,85,217),rgb(174,187,255))}
-.af-tag.green{background:light-dark(rgba(16,163,106,.11),rgba(70,205,145,.16));color:light-dark(rgb(13,114,71),rgb(130,226,177))}
-.af-tag.orange{background:light-dark(rgba(234,138,20,.12),rgba(255,168,70,.16));color:light-dark(rgb(162,92,6),rgb(255,196,137))}
-.af-tag.pink{background:light-dark(rgba(226,62,128,.10),rgba(255,111,166,.16));color:light-dark(rgb(184,48,106),rgb(255,166,198))}
+.af-tag.blue{background:var(--dsw-alias-state-business-tertiary);color:var(--dsw-alias-state-business-primary)}
+.af-tag.green{background:var(--dsw-alias-state-success-tertiary);color:var(--dsw-alias-state-success-primary)}
+.af-tag.orange{background:var(--dsw-alias-state-warn-tertiary);color:var(--dsw-alias-state-warn-label)}
+.af-tag.pink{background:var(--dsw-alias-interactive-bg-hover-danger);color:var(--dsw-alias-state-error-primary)}
 .af-ago{color:var(--dsw-alias-label-tertiary);font-size:12px;margin-top:auto}
 .af-overlay{position:fixed;inset:0;z-index:2147483000;background:var(--dsw-alias-bg-mask-3);display:flex;align-items:center;justify-content:center;padding:24px 16px;box-sizing:border-box}
 .af-drawer{position:relative;width:min(720px,100%);max-height:min(86vh,840px);margin:0 auto;background:var(--dsw-alias-bg-layer-1);border:1px solid var(--dsw-alias-border-l2);border-radius:12px;overflow:hidden;display:flex;flex-direction:column}


### PR DESCRIPTION
## 改动说明

用 Harness semantic token 替换插件 UI 中的硬编码颜色，修复深色主题下卡片、标签和配置项对比度。合并 `main` 时保留版本检查区块，并把该区块的颜色一并映射到同一套 token。

## 改动类型

- [x] Bug 修复
- [ ] 新功能或来源
- [x] UI / 交互调整
- [ ] 重构
- [ ] 测试或文档

## 验证

- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] 已在 Harness Web 中手动验证（如适用）
- [ ] UI 改动已附截图（如适用）

## 安全与隐私

- [x] 未包含密钥、Cookie、个人数据、私有网络信息或本地配置
- [x] 新增网络请求设置了超时，并能处理来源失败

## 关联 Issue


Made with [Cursor](https://cursor.com)