### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anime-find",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "DeepSeek Harness 插件：对话内多源搜番，卡片详情与磁力复制",
   "homepage": "https://github.com/cocofhu/anime-find#readme",
   "bugs": {


### PR DESCRIPTION
## 改动说明

将 `package.json` 版本升到 0.1.1，便于打正式 Release。插件设置里的当前版本会读这个字段。

## 改动类型

- [x] Bug 修复
- [ ] 新功能或来源
- [ ] UI / 交互调整
- [ ] 重构
- [x] 测试或文档

## 验证

- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] 已在 Harness Web 中手动验证（如适用）
- [ ] UI 改动已附截图（如适用）

## 安全与隐私

- [x] 未包含密钥、Cookie、个人数据、私有网络信息或本地配置
- [x] 新增网络请求设置了超时，并能处理来源失败

Made with [Cursor](https://cursor.com)