### PR TITLE
Fill Bangumi card data and fix empty resource rows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anime-find",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "DeepSeek Harness 插件：对话内多源搜番，卡片详情与磁力复制",
   "homepage": "https://github.com/cocofhu/anime-find#readme",
   "bugs": {

--- a/src/bangumi.ts
+++ b/src/bangumi.ts
@@ -1,5 +1,5 @@
 import { fetchJson } from './http.js'
-import type { AnimeDetailMeta, BangumiComment, BangumiMetaResult, PluginConfig } from './types.js'
+import type { AnimeCard, AnimeDetailMeta, BangumiComment, BangumiMetaResult, FetchOptions, PluginConfig } from './types.js'
 
 type Subject = {
   name?: string
@@ -33,6 +33,12 @@ type CommentResponse = {
     updatedAt?: number | string
     user?: { nickname?: string; avatar?: Avatar }
   }>
+}
+
+type SearchHit = Subject & { id?: number }
+
+type SearchResponse = {
+  data?: SearchHit[]
 }
 
 const BGM_API = 'https://api.bgm.tv/v0'
@@ -83,9 +89,92 @@ export function mapSubject(bgmId: string, subject: Subject, persons: Person[] = 
     score: finiteNumber(subject.rating?.score),
     ratingCount: finiteNumber(subject.rating?.total),
     pageUrl: `https://bgm.tv/subject/${bgmId}`,
-    tags: (subject.tags || []).map((tag) => cleanText(tag.name)).filter((name): name is string => !!name).slice(0, 3),
+    tags: subjectTags(subject),
     chips,
   }
+}
+
+export function cardFieldsFromSubject(bgmId: string, subject: Subject): Partial<AnimeCard> {
+  const nameCn = cleanText(subject.name_cn)
+  const name = cleanText(subject.name)
+  return {
+    bgmId,
+    ...(name || nameCn ? { nameOrig: name || nameCn } : {}),
+    score: finiteNumber(subject.rating?.score),
+    ratingCount: finiteNumber(subject.rating?.total),
+    tags: subjectTags(subject),
+  }
+}
+
+export async function enrichCardsWithBangumi(
+  cards: AnimeCard[],
+  config: PluginConfig,
+  signal?: AbortSignal,
+): Promise<void> {
+  if (!cards.length) return
+  const options = { timeoutMs: Math.min(config.timeoutMs, 4000), userAgent: config.userAgent }
+  await mapLimit(cards, 4, async (card) => {
+    if (signal?.aborted) return
+    if (card.bgmId && card.score != null && card.tags?.length) return
+    try {
+      const resolved = await resolveSubject(card, options, signal)
+      if (!resolved) return
+      applyCardFields(card, cardFieldsFromSubject(resolved.bgmId, resolved.subject))
+    } catch { /* keep the original card when Bangumi is unavailable */ }
+  })
+}
+
+async function resolveSubject(
+  card: AnimeCard,
+  options: FetchOptions,
+  signal?: AbortSignal,
+): Promise<{ bgmId: string; subject: Subject } | undefined> {
+  if (card.bgmId) {
+    const subject = await fetchJson<Subject>(`${BGM_API}/subjects/${card.bgmId}`, options, signal)
+    return { bgmId: card.bgmId, subject }
+  }
+  const hit = await searchSubject(card.title, options, signal)
+  if (!hit?.id) return undefined
+  const bgmId = String(hit.id)
+  if (hit.name || hit.name_cn || hit.rating || hit.tags?.length) return { bgmId, subject: hit }
+  const subject = await fetchJson<Subject>(`${BGM_API}/subjects/${bgmId}`, options, signal)
+  return { bgmId, subject }
+}
+
+async function searchSubject(title: string, options: FetchOptions, signal?: AbortSignal): Promise<SearchHit | undefined> {
+  const keyword = title.trim()
+  if (keyword.length < 2) return undefined
+  const found = await fetchJson<SearchResponse>(`${BGM_API}/search/subjects?limit=1`, options, signal, {
+    method: 'POST',
+    body: JSON.stringify({ keyword, sort: 'match', filter: { type: [2] } }),
+  })
+  const hit = found.data?.[0]
+  return typeof hit?.id === 'number' && Number.isFinite(hit.id) ? hit : undefined
+}
+
+function applyCardFields(card: AnimeCard, fields: Partial<AnimeCard>): void {
+  if (fields.bgmId) card.bgmId = fields.bgmId
+  if (fields.title) card.title = fields.title
+  if (fields.nameOrig) card.nameOrig = fields.nameOrig
+  if (fields.score != null) card.score = fields.score
+  if (fields.ratingCount != null) card.ratingCount = fields.ratingCount
+  if (fields.tags?.length) card.tags = fields.tags
+}
+
+function subjectTags(subject: Subject): string[] {
+  return (subject.tags || []).map((tag) => cleanText(tag.name)).filter((name): name is string => !!name).slice(0, 3)
+}
+
+async function mapLimit<T>(items: T[], limit: number, worker: (item: T) => Promise<void>): Promise<void> {
+  let index = 0
+  const run = async () => {
+    while (index < items.length) {
+      const current = items[index]
+      index += 1
+      await worker(current)
+    }
+  }
+  await Promise.all(Array.from({ length: Math.max(1, Math.min(limit, items.length)) }, () => run()))
 }
 
 export function mapComments(response: CommentResponse): BangumiComment[] {

--- a/src/client.js
+++ b/src/client.js
@@ -14,7 +14,7 @@ window.__ModuleLoader__.load({
 .af-mini.primary{background:var(--dsw-alias-button-primary-fill);color:var(--dsw-alias-label-primary-foreground);border-color:transparent}
 .af-week{font-weight:700;font-size:13px;margin:8px 0 6px}
 .af-cards{display:grid;grid-template-columns:1fr;gap:10px}
-.af-card{display:flex;gap:12px;align-items:stretch;background:var(--dsw-alias-bg-layer-2);border:1px solid var(--dsw-alias-border-l1);border-radius:12px;padding:12px;cursor:pointer;text-align:left;width:100%;font:inherit;color:var(--dsw-alias-label-primary)}
+.af-card{display:flex;gap:12px;align-items:flex-start;background:var(--dsw-alias-bg-layer-2);border:1px solid var(--dsw-alias-border-l1);border-radius:12px;padding:12px;cursor:pointer;text-align:left;width:100%;font:inherit;color:var(--dsw-alias-label-primary)}
 .af-card:hover{border-color:var(--dsw-alias-border-l2);background:var(--dsw-alias-interactive-bg-hover)}
 .af-card:focus-visible{outline:2px solid var(--dsw-alias-brand-primary-new-colorprimary-new-color);outline-offset:2px}
 .af-card.busy{cursor:wait}
@@ -22,7 +22,7 @@ window.__ModuleLoader__.load({
 .af-meta{min-width:0;flex:1;display:flex;flex-direction:column;gap:5px}
 .af-title{font-weight:700;font-size:15px;line-height:1.35;color:var(--dsw-alias-label-primary);display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}
 .af-score{color:var(--dsw-alias-state-business-primary);font-weight:800;font-size:16px}
-.af-tags{display:flex;flex-wrap:wrap;gap:6px;margin-top:auto}
+.af-tags{display:flex;flex-wrap:wrap;gap:6px;margin-top:2px}
 .af-tag{font-size:11px;padding:3px 8px;border-radius:999px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%;background:var(--dsw-alias-markdown-tag);color:var(--dsw-alias-label-secondary)}
 .af-tag.blue{background:var(--dsw-alias-state-business-tertiary);color:var(--dsw-alias-state-business-primary)}
 .af-tag.green{background:var(--dsw-alias-state-success-tertiary);color:var(--dsw-alias-state-success-primary)}
@@ -36,6 +36,8 @@ window.__ModuleLoader__.load({
 .af-dcover{width:84px;height:118px;border-radius:8px;object-fit:cover;border:1px solid var(--dsw-alias-border-l1);background:var(--dsw-alias-bg-layer-3);flex-shrink:0}
 .af-head h2{margin:0 0 6px;font-size:18px;line-height:1.35;color:var(--dsw-alias-label-primary)}
 .af-body{flex:1;min-height:0;overflow:auto;padding:12px 18px 20px;display:flex;flex-direction:column}
+.af-body>*{flex-shrink:0}
+.af-body>.af-load{flex:1;min-height:0}
 .af-original{color:var(--dsw-alias-label-tertiary);font-size:12px;margin:0;line-height:1.4}
 .af-card .af-original{margin:0}
 .af-head .af-original{margin:-2px 0 4px}
@@ -66,11 +68,11 @@ window.__ModuleLoader__.load({
 .af-pill{font:inherit;font-size:12px;padding:5px 13px;border-radius:999px;border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-layer-1);color:var(--dsw-alias-label-caption);cursor:pointer;transition:background .16s ease,border-color .16s ease,color .16s ease}
 .af-pill:hover{background:var(--dsw-alias-bg-layer-2);border-color:var(--dsw-alias-border-l2);color:var(--dsw-alias-label-primary)}
 .af-pill.on{background:var(--dsw-alias-button-ghost-active-fill);color:var(--dsw-alias-brand-primary-new-colorprimary-new-color);border-color:var(--dsw-alias-brand-primary-new-colorprimary-new-color);font-weight:600}
-.af-group{border:1px solid var(--dsw-alias-border-l2);border-radius:10px;margin-bottom:10px;overflow:hidden;background:var(--dsw-alias-bg-layer-1)}
-.af-group summary{cursor:pointer;padding:11px 14px;display:flex;gap:10px;align-items:center;font-weight:600;background:var(--dsw-alias-bg-layer-2);list-style:none;transition:background .16s ease}
+.af-group{border:1px solid var(--dsw-alias-border-l2);border-radius:10px;margin-bottom:10px;overflow:hidden;background:var(--dsw-alias-bg-layer-1);flex-shrink:0}
+.af-group summary{cursor:pointer;padding:11px 14px;display:flex;gap:10px;align-items:center;font-weight:600;background:var(--dsw-alias-bg-layer-2);list-style:none;transition:background .16s ease;min-width:0}
 .af-group summary::-webkit-details-marker{display:none}
 .af-group summary:hover{background:var(--dsw-alias-bg-layer-3)}
-.af-sub{font-weight:400;color:var(--dsw-alias-label-tertiary);font-size:12px;margin-left:auto}
+.af-sub{font-weight:400;color:var(--dsw-alias-label-tertiary);font-size:12px;margin-left:auto;flex-shrink:0}
 .af-ep{border-top:1px solid var(--dsw-alias-border-l2)}
 .af-ep:first-of-type{border-top:0}
 .af-ep-h{display:flex;align-items:center;gap:8px;padding:12px 14px 6px;font-size:12px;font-weight:600;color:var(--dsw-alias-label-tertiary);letter-spacing:.04em}
@@ -78,8 +80,7 @@ window.__ModuleLoader__.load({
 .af-item{padding:9px 14px;display:grid;grid-template-columns:minmax(0,1fr) auto;gap:14px;align-items:center;border-radius:8px;margin:0 6px;transition:background .14s ease}
 .af-item:hover{background:var(--dsw-alias-bg-layer-2)}
 .af-item + .af-item{border-top:1px solid var(--dsw-alias-border-l2)}
-.af-item-raw{max-height:0;opacity:0;margin:3px 0 0;color:var(--dsw-alias-label-tertiary);font-size:11px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;transition:max-height .18s ease,opacity .18s ease}
-.af-item:hover .af-item-raw{max-height:20px;opacity:1}
+.af-item-raw{margin:3px 0 0;color:var(--dsw-alias-label-tertiary);font-size:11px;line-height:1.4;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 .af-chips{display:flex;flex-wrap:wrap;gap:6px}
 .af-chip{font-size:11px;line-height:1;padding:4px 8px;border-radius:6px;background:var(--dsw-alias-bg-layer-3);color:var(--dsw-alias-label-caption);border:1px solid transparent}
 .af-chip.hi{background:var(--dsw-alias-button-ghost-active-fill);color:var(--dsw-alias-brand-primary-new-colorprimary-new-color);border-color:var(--dsw-alias-brand-primary-new-colorprimary-new-color);font-weight:600}
@@ -244,7 +245,7 @@ window.__ModuleLoader__.load({
     const TAG_TONES = ["green", "pink", "blue"];
 
     function Tags({ item, labels }) {
-      const fromLabels = (labels || []).map(String).map((t) => t.trim()).filter(Boolean).slice(0, 3);
+      const fromLabels = (labels || item.tags || []).map(String).map((t) => t.trim()).filter(Boolean).slice(0, 3);
       const tags = fromLabels.length
         ? fromLabels.map((label, i) => [TAG_TONES[i % TAG_TONES.length], label])
         : [
@@ -262,12 +263,48 @@ window.__ModuleLoader__.load({
       );
     }
 
+    function needsBangumi(item) {
+      return item && (!item.bgmId || item.score == null || !(item.tags && item.tags.length));
+    }
+
+    function mergeBangumi(item, extra) {
+      if (!extra) return item;
+      return {
+        ...item,
+        bgmId: extra.bgmId || item.bgmId,
+        nameOrig: extra.nameOrig || item.nameOrig,
+        score: extra.score ?? item.score,
+        ratingCount: extra.ratingCount ?? item.ratingCount,
+        tags: extra.tags?.length ? extra.tags : item.tags,
+      };
+    }
+
     function Cards({ items, onOpen, pendingId, onPrefetch, hideEmpty }) {
+      const [extra, setExtra] = useState({});
+      const ids = (items || []).map((it) => it.id).join("\n");
+      useEffect(() => {
+        let live = true;
+        const missing = (items || []).filter(needsBangumi);
+        if (!missing.length) return () => { live = false; };
+        Promise.all(missing.map((it) => api("bangumiCard", { id: it.id, title: it.title, bgmId: it.bgmId }).then(
+          (data) => ({ id: it.id, data }),
+          () => null,
+        ))).then((rows) => {
+          if (!live) return;
+          const next = {};
+          for (const row of rows) {
+            if (row?.data && (row.data.bgmId || row.data.score != null || row.data.tags?.length)) next[row.id] = row.data;
+          }
+          if (Object.keys(next).length) setExtra((prev) => ({ ...prev, ...next }));
+        });
+        return () => { live = false; };
+      }, [ids]);
       if (!items?.length) return hideEmpty ? null : h("div", { className: "af-hint" }, "没有结果");
       return h(
         "div",
         { className: "af-cards" },
-        items.map((item) => {
+        items.map((raw) => {
+          const item = mergeBangumi(raw, extra[raw.id]);
           const score = item.score;
           const bangumiUrl = item.bgmId ? `https://bgm.tv/subject/${item.bgmId}` : "";
           return h(
@@ -291,7 +328,7 @@ window.__ModuleLoader__.load({
             h("div", { className: "af-meta" },
               h("div", { className: "af-title", title: item.title }, item.title),
               item.nameOrig ? h("div", { className: "af-original" }, item.nameOrig) : null,
-              score != null ? h(RatingRow, { score }) : null,
+              score != null ? h(RatingRow, { score, count: item.ratingCount }) : null,
               bangumiUrl ? h("a", {
                 className: "af-bgm-link",
                 href: bangumiUrl,
@@ -487,7 +524,7 @@ window.__ModuleLoader__.load({
           h("div", { style: { minWidth: 0, flex: 1 } },
             h("h2", null, title),
             nameOrig ? h("div", { className: "af-original" }, nameOrig) : null,
-            h(RatingRow, { score, count: intro?.ratingCount }),
+            h(RatingRow, { score, count: intro?.ratingCount ?? item.ratingCount }),
             bangumiPageUrl ? h("a", { className: "af-bgm-link", href: bangumiPageUrl, target: "_blank", rel: "noreferrer" }, "Bangumi 条目") : null,
             h(Tags, { item: { ...item, ...(detail || {}) }, labels: intro?.tags }),
           ),

--- a/src/host.ts
+++ b/src/host.ts
@@ -3,11 +3,11 @@ import type { Context } from '@deepseek-ai/cordis'
 import { defineTool } from '@deepseek-ai/dsh-tools'
 import Schema from '@deepseek-ai/schemastery'
 import { assignConfig, publicConfig, readOverlay, sanitizePatch, sanitizeSources, writeOverlay } from './config-store.js'
-import { loadBangumiMeta } from './bangumi.js'
+import { enrichCardsWithBangumi, loadBangumiMeta } from './bangumi.js'
 import { fetchBytes } from './http.js'
 import { detailAnime, isSeasonBrowse, searchAnime } from './search.js'
 import { parseSeasonHint } from './season.js'
-import type { PluginConfig, SearchResult, SourceId } from './types.js'
+import type { PluginConfig, SearchResult, SourceId, AnimeCard } from './types.js'
 import { checkForUpdate, getVersionMetadata } from './update-check.js'
 
 export const name = 'anime-find'
@@ -188,6 +188,27 @@ async function handleApi(req: IncomingMessage, res: ServerResponse, cfg: PluginC
       if (!/^\d+$/.test(bgmId)) return sendJson(res, 400, { ok: false, error: '缺少有效的 bgmId' })
       const meta = await loadBangumiMeta(bgmId, cfg)
       return sendJson(res, 200, { ok: true, ...meta })
+    }
+    if (method === 'bangumiCard') {
+      const title = String(body.title || '').trim()
+      const bgmId = String(body.bgmId || url.searchParams.get('bgmId') || '').trim()
+      if (title.length < 2 && !/^\d+$/.test(bgmId)) return sendJson(res, 400, { ok: false, error: '缺少标题或 bgmId' })
+      const card: AnimeCard = {
+        id: String(body.id || title || bgmId),
+        title: title || bgmId,
+        ...( /^\d+$/.test(bgmId) ? { bgmId } : {}),
+        sources: [],
+        refs: {},
+      }
+      await enrichCardsWithBangumi([card], cfg)
+      return sendJson(res, 200, {
+        ok: true,
+        bgmId: card.bgmId,
+        nameOrig: card.nameOrig,
+        score: card.score,
+        ratingCount: card.ratingCount,
+        tags: card.tags,
+      })
     }
     if (method === 'config') {
       if (body.save) {

--- a/src/http.ts
+++ b/src/http.ts
@@ -14,8 +14,8 @@ export async function fetchText(url: string, options: FetchOptions, signal?: Abo
   return res.text()
 }
 
-export async function fetchJson<T>(url: string, options: FetchOptions, signal?: AbortSignal): Promise<T> {
-  const res = await request(url, options, signal)
+export async function fetchJson<T>(url: string, options: FetchOptions, signal?: AbortSignal, init?: { method?: string; body?: string }): Promise<T> {
+  const res = await request(url, options, signal, init)
   return res.json() as Promise<T>
 }
 
@@ -25,15 +25,19 @@ export async function fetchBytes(url: string, options: FetchOptions, signal?: Ab
   return { body: buf, contentType: res.headers.get('content-type') || 'application/octet-stream' }
 }
 
-async function request(url: string, options: FetchOptions, signal?: AbortSignal): Promise<Response> {
+async function request(url: string, options: FetchOptions, signal?: AbortSignal, init?: { method?: string; body?: string }): Promise<Response> {
   const ctrl = new AbortController()
   const timer = setTimeout(() => ctrl.abort(), options.timeoutMs)
   const onAbort = () => ctrl.abort()
   signal?.addEventListener('abort', onAbort, { once: true })
   try {
+    const headers: Record<string, string> = { 'user-agent': options.userAgent, accept: init?.body ? 'application/json' : '*/*' }
+    if (init?.body) headers['content-type'] = 'application/json'
     const res = await fetch(url, {
       signal: ctrl.signal,
-      headers: { 'user-agent': options.userAgent, accept: '*/*' },
+      method: init?.method,
+      headers,
+      body: init?.body,
     })
     if (!res.ok) throw new HttpError(`HTTP ${res.status} ${url}`, res.status)
     return res

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -43,6 +43,7 @@ function cloneCard(card: AnimeCard): AnimeCard {
     sources: [...card.sources],
     refs: { ...card.refs },
     resourceCount: positiveCount(card.resourceCount),
+    tags: card.tags ? [...card.tags] : undefined,
   }
 }
 
@@ -55,6 +56,8 @@ function absorbCard(existing: AnimeCard, card: AnimeCard): void {
   existing.pageUrl ||= card.pageUrl
   existing.bgmId ||= card.bgmId
   existing.nameOrig ||= card.nameOrig
+  existing.ratingCount ??= card.ratingCount
+  if (!existing.tags?.length && card.tags?.length) existing.tags = [...card.tags]
   existing.season ||= card.season
   existing.subgroup ||= card.subgroup
   existing.format ||= card.format

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,3 +1,4 @@
+import { enrichCardsWithBangumi } from './bangumi.js'
 import { mergeCards, parseId } from './normalize.js'
 import { parseRelease } from './release.js'
 import { parseSeasonHint, resolveAnimeSeason, seasonLabel } from './season.js'
@@ -37,7 +38,7 @@ export async function searchAnime(
       )
     }
     await Promise.all(jobs)
-    return paginate(seasonLabel(season), lists, errors, config)
+    return paginate(seasonLabel(season), lists, errors, config, signal)
   }
 
   const jobs: Array<Promise<void>> = []
@@ -63,19 +64,21 @@ export async function searchAnime(
     )
   }
   await Promise.all(jobs)
-  return paginate(q, lists, errors, config)
+  return paginate(q, lists, errors, config, signal)
 }
 
-function paginate(
+async function paginate(
   query: string,
   lists: AnimeCard[][],
   errors: SourceError[],
   config: PluginConfig & { offset?: number },
-): SearchResult {
+  signal?: AbortSignal,
+): Promise<SearchResult> {
   const all = mergeCards(lists, 1000)
   const offset = Math.max(0, Math.floor(Number(config.offset) || 0))
   const limit = Math.max(1, config.maxResults || 12)
   const items = all.slice(offset, offset + limit)
+  await enrichCardsWithBangumi(items, config, signal)
   return {
     query,
     items,

--- a/src/tests/parse.test.ts
+++ b/src/tests/parse.test.ts
@@ -10,8 +10,8 @@ import { parseRelease, groupReleases } from '../release.js'
 import { isSeasonBrowse } from '../search.js'
 import { currentAnimeSeason, parseSeasonHint, resolveAnimeSeason } from '../season.js'
 import { DEFAULT_SOURCES, sanitizeSources } from '../config-store.js'
-import { loadBangumiMeta, mapComments, mapSubject } from '../bangumi.js'
-import type { PluginConfig } from '../types.js'
+import { cardFieldsFromSubject, enrichCardsWithBangumi, loadBangumiMeta, mapComments, mapSubject } from '../bangumi.js'
+import type { AnimeCard, PluginConfig } from '../types.js'
 
 const dir = dirname(fileURLToPath(import.meta.url))
 const fixture = (name: string) => readFileSync(join(dir, 'fixtures', name), 'utf8')
@@ -61,6 +61,109 @@ test('mapSubject maps Bangumi metadata and optional chips', () => {
     { label: '原作', value: '高橋留美子' },
     { label: '动画制作', value: 'OLM' },
   ])
+})
+
+test('cardFieldsFromSubject maps search-card Bangumi fields without replacing the title', () => {
+  const subject = JSON.parse(fixture('bangumi-subject.json'))
+  const fields = cardFieldsFromSubject('481410', subject)
+  assert.equal(fields.bgmId, '481410')
+  assert.equal(fields.title, undefined)
+  assert.equal(fields.nameOrig, 'MAO')
+  assert.equal(fields.score, 7.8)
+  assert.equal(fields.ratingCount, 1284)
+  assert.deepEqual(fields.tags, ['原创', '奇幻', '战斗'])
+})
+
+test('enrichCardsWithBangumi fills score, tags and Bangumi id from search', async () => {
+  const originalFetch = globalThis.fetch
+  const config: PluginConfig = {
+    mikanHost: 'https://mikanani.me',
+    anibtHost: 'https://anibt.net',
+    gardenHost: 'https://api.animes.garden',
+    timeoutMs: 1000,
+    userAgent: 'anime-find test',
+    maxResults: 12,
+    sources: ['mikan'],
+  }
+  const cards: AnimeCard[] = [{ id: 'mikan:1', title: '摩绪', sources: ['mikan'], refs: { mikan: '1' } }]
+  try {
+    globalThis.fetch = async (input, init) => {
+      const url = String(input)
+      if (url.includes('/search/subjects')) {
+        assert.equal(init?.method, 'POST')
+        return new Response(JSON.stringify({
+          data: [{
+            id: 481410,
+            name: 'MAO',
+            name_cn: '摩绪',
+            rating: { score: 7.8, total: 1284 },
+            tags: [{ name: '原创' }, { name: '奇幻' }, { name: '战斗' }, { name: '少年' }],
+          }],
+        }))
+      }
+      return new Response('unexpected ' + url, { status: 404 })
+    }
+    await enrichCardsWithBangumi(cards, config)
+    assert.equal(cards[0].title, '摩绪')
+    assert.equal(cards[0].bgmId, '481410')
+    assert.equal(cards[0].nameOrig, 'MAO')
+    assert.equal(cards[0].score, 7.8)
+    assert.equal(cards[0].ratingCount, 1284)
+    assert.deepEqual(cards[0].tags, ['原创', '奇幻', '战斗'])
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test('enrichCardsWithBangumi loads a subject by existing bgmId', async () => {
+  const originalFetch = globalThis.fetch
+  const config: PluginConfig = {
+    mikanHost: 'https://mikanani.me',
+    anibtHost: 'https://anibt.net',
+    gardenHost: 'https://api.animes.garden',
+    timeoutMs: 1000,
+    userAgent: 'anime-find test',
+    maxResults: 12,
+    sources: ['mikan'],
+  }
+  const cards: AnimeCard[] = [{ id: 'mikan:1', title: '摩绪', bgmId: '481410', sources: ['mikan'], refs: { mikan: '1' } }]
+  try {
+    globalThis.fetch = async (input) => {
+      const url = String(input)
+      if (url.includes('/search/subjects')) return new Response('should use id', { status: 500 })
+      if (url.endsWith('/subjects/481410')) return new Response(fixture('bangumi-subject.json'))
+      return new Response('unexpected ' + url, { status: 404 })
+    }
+    await enrichCardsWithBangumi(cards, config)
+    assert.equal(cards[0].score, 7.8)
+    assert.equal(cards[0].nameOrig, 'MAO')
+    assert.deepEqual(cards[0].tags, ['原创', '奇幻', '战斗'])
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test('enrichCardsWithBangumi keeps the original card when Bangumi fails', async () => {
+  const originalFetch = globalThis.fetch
+  const config: PluginConfig = {
+    mikanHost: 'https://mikanani.me',
+    anibtHost: 'https://anibt.net',
+    gardenHost: 'https://api.animes.garden',
+    timeoutMs: 1000,
+    userAgent: 'anime-find test',
+    maxResults: 12,
+    sources: ['mikan'],
+  }
+  const cards: AnimeCard[] = [{ id: 'mikan:1', title: '摩绪', sources: ['mikan'], refs: { mikan: '1' } }]
+  try {
+    globalThis.fetch = async () => new Response('unavailable', { status: 503 })
+    await enrichCardsWithBangumi(cards, config)
+    assert.equal(cards[0].bgmId, undefined)
+    assert.equal(cards[0].score, undefined)
+    assert.equal(cards[0].title, '摩绪')
+  } finally {
+    globalThis.fetch = originalFetch
+  }
 })
 
 test('mapComments limits and normalizes Bangumi comments', () => {
@@ -152,6 +255,17 @@ test('mergeCards overlays garden resource counts onto same-title cards', () => {
   assert.equal(main?.resourceCount, 80)
   assert.ok(main?.sources.includes('anibt'))
   assert.ok(main?.sources.includes('garden'))
+})
+
+test('mergeCards overlays Bangumi tags and rating counts', () => {
+  const merged = mergeCards([
+    [{ id: 'mikan:1', title: '摩绪', sources: ['mikan'], refs: { mikan: '1' } }],
+    [{ id: 'anibt:9', title: '摩绪', sources: ['anibt'], refs: { anibt: '9' }, bgmId: '481410', ratingCount: 1284, tags: ['原创', '奇幻', '战斗'] }],
+  ], 10)
+  assert.equal(merged.length, 1)
+  assert.equal(merged[0].bgmId, '481410')
+  assert.equal(merged[0].ratingCount, 1284)
+  assert.deepEqual(merged[0].tags, ['原创', '奇幻', '战斗'])
 })
 
 test('sanitizeSources defaults to mikan only', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,8 @@ export interface AnimeCard {
   format?: string
   subgroup?: string
   resourceCount?: number
+  ratingCount?: number
+  tags?: string[]
   sources: SourceId[]
   refs: Partial<Record<SourceId, string>>
 }


### PR DESCRIPTION
## 改动说明

搜索卡片中间不再留白，详情资源列表也不再被压成空框：

- 搜索时为当前页补全 Bangumi 原名、评分、条目链接和前 3 个 Tag
- 卡片没有 Bangumi 数据时，客户端会再请求一次补全
- 详情资源列表不再被 flex 压缩成空框，文件名始终可见
- 版本号升到 0.1.2，便于合并后打正式 Release

## 改动类型

- [x] Bug 修复
- [ ] 新功能或来源
- [x] UI / 交互调整
- [ ] 重构
- [x] 测试或文档

## 验证

- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] 已在 Harness Web 中手动验证（如适用）
- [ ] UI 改动已附截图（如适用）

## 安全与隐私

- [x] 未包含密钥、Cookie、个人数据、私有网络信息或本地配置
- [x] 新增网络请求设置了超时，并能处理来源失败

## 关联 Issue


Made with [Cursor](https://cursor.com)