### PR TITLE
Fix plugin API 404 behind a path-prefix proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anime-find",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "DeepSeek Harness 插件：对话内多源搜番，卡片详情与磁力复制",
   "homepage": "https://github.com/cocofhu/anime-find#readme",
   "bugs": {

--- a/src/client.js
+++ b/src/client.js
@@ -180,14 +180,59 @@ window.__ModuleLoader__.load({
       );
     }
 
+    const PLUGIN_SCRIPT_PATH = "/plugins/anime-find/client.js";
+
+    function prefixFromPluginUrl(src) {
+      try {
+        const path = new URL(src, typeof location !== "undefined" ? location.href : "http://local/").pathname;
+        const idx = path.indexOf(PLUGIN_SCRIPT_PATH);
+        if (idx <= 0) return "";
+        return path.slice(0, idx).replace(/\/+$/, "");
+      } catch { return ""; }
+    }
+
+    function prefixFromPathname(pathname) {
+      const first = String(pathname || "/").split("/").filter(Boolean)[0];
+      if (!first || !/^[A-Za-z0-9_-]{16,}$/.test(first)) return "";
+      return "/" + first;
+    }
+
+    function sitePrefix() {
+      if (typeof document !== "undefined") {
+        for (const s of document.getElementsByTagName("script")) {
+          const prefix = s.src ? prefixFromPluginUrl(s.src) : "";
+          if (prefix) return prefix;
+        }
+        const href = document.querySelector("base")?.getAttribute("href");
+        if (href) {
+          try {
+            const path = new URL(href, location.href).pathname.replace(/\/+$/, "");
+            if (path && path !== "/") return path;
+          } catch { /* ignore malformed base href */ }
+        }
+      }
+      try {
+        for (const e of performance.getEntriesByType("resource")) {
+          const prefix = e.name ? prefixFromPluginUrl(e.name) : "";
+          if (prefix) return prefix;
+        }
+      } catch { /* performance API unavailable */ }
+      return typeof location !== "undefined" ? prefixFromPathname(location.pathname) : "";
+    }
+
+    function pluginUrl(path) {
+      const suffix = path.startsWith("/") ? path : "/" + path;
+      return sitePrefix() + suffix;
+    }
+
     function coverSrc(url, title) {
       if (!url) return placeholder(title);
       if (url.startsWith("data:")) return url;
-      return "/anime-find/cover?url=" + encodeURIComponent(url);
+      return pluginUrl("/anime-find/cover") + "?url=" + encodeURIComponent(url);
     }
 
     async function api(method, payload) {
-      const res = await fetch("/anime-find", {
+      const res = await fetch(pluginUrl("/anime-find"), {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ method, ...payload }),

--- a/src/public-path.ts
+++ b/src/public-path.ts
@@ -1,0 +1,48 @@
+const PLUGIN_SCRIPT_PATH = '/plugins/anime-find/client.js'
+
+export function prefixFromPluginUrl(src: string, base = 'http://local/'): string {
+  try {
+    const path = new URL(src, base).pathname
+    const idx = path.indexOf(PLUGIN_SCRIPT_PATH)
+    if (idx <= 0) return ''
+    return path.slice(0, idx).replace(/\/+$/, '')
+  } catch {
+    return ''
+  }
+}
+
+export function prefixFromPathname(pathname: string): string {
+  const first = (pathname || '/').split('/').filter(Boolean)[0]
+  if (!first || !/^[A-Za-z0-9_-]{16,}$/.test(first)) return ''
+  return `/${first}`
+}
+
+export function prefixFromBaseHref(href: string, pagePath = '/'): string {
+  try {
+    const path = new URL(href, `http://local${pagePath.startsWith('/') ? pagePath : `/${pagePath}`}`).pathname.replace(/\/+$/, '')
+    return path && path !== '/' ? path : ''
+  } catch {
+    return ''
+  }
+}
+
+export function resolveSitePrefix(input: {
+  scriptUrls?: string[]
+  pathname?: string
+  baseHref?: string
+}): string {
+  for (const src of input.scriptUrls || []) {
+    const prefix = prefixFromPluginUrl(src)
+    if (prefix) return prefix
+  }
+  if (input.baseHref) {
+    const prefix = prefixFromBaseHref(input.baseHref, input.pathname)
+    if (prefix) return prefix
+  }
+  return prefixFromPathname(input.pathname || '/')
+}
+
+export function pluginUrl(path: string, prefix = ''): string {
+  const suffix = path.startsWith('/') ? path : `/${path}`
+  return `${prefix}${suffix}`
+}

--- a/src/tests/public-path.test.ts
+++ b/src/tests/public-path.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { pluginUrl, prefixFromPathname, prefixFromPluginUrl, resolveSitePrefix } from '../public-path.js'
+
+test('plugin script under a proxy prefix yields that prefix', () => {
+  assert.equal(
+    prefixFromPluginUrl('https://43.161.238.167:38012/p7fco3lmrlo69rpziq5xl0uv/plugins/anime-find/client.js?rev=abc'),
+    '/p7fco3lmrlo69rpziq5xl0uv',
+  )
+})
+
+test('plugin script at site root has no prefix', () => {
+  assert.equal(prefixFromPluginUrl('http://127.0.0.1:3080/plugins/anime-find/client.js?rev=abc'), '')
+  assert.equal(prefixFromPluginUrl('/plugins/anime-find/client.js'), '')
+})
+
+test('proxy token pathnames keep the first segment', () => {
+  assert.equal(prefixFromPathname('/p7fco3lmrlo69rpziq5xl0uv/'), '/p7fco3lmrlo69rpziq5xl0uv')
+  assert.equal(prefixFromPathname('/p7fco3lmrlo69rpziq5xl0uv'), '/p7fco3lmrlo69rpziq5xl0uv')
+  assert.equal(prefixFromPathname('/p7fco3lmrlo69rpziq5xl0uv/settings'), '/p7fco3lmrlo69rpziq5xl0uv')
+})
+
+test('ordinary SPA paths are not treated as a proxy prefix', () => {
+  assert.equal(prefixFromPathname('/'), '')
+  assert.equal(prefixFromPathname('/settings'), '')
+  assert.equal(prefixFromPathname('/workspace'), '')
+})
+
+test('resolveSitePrefix prefers the plugin script URL over the page path', () => {
+  assert.equal(resolveSitePrefix({
+    scriptUrls: ['https://host/p7fco3lmrlo69rpziq5xl0uv/plugins/anime-find/client.js'],
+    pathname: '/',
+  }), '/p7fco3lmrlo69rpziq5xl0uv')
+  assert.equal(resolveSitePrefix({
+    scriptUrls: ['/plugins/anime-find/client.js'],
+    pathname: '/p7fco3lmrlo69rpziq5xl0uv/',
+  }), '/p7fco3lmrlo69rpziq5xl0uv')
+  assert.equal(resolveSitePrefix({
+    scriptUrls: ['/plugins/anime-find/client.js'],
+    pathname: '/',
+  }), '')
+})
+
+test('pluginUrl joins the prefix and route', () => {
+  assert.equal(pluginUrl('/anime-find'), '/anime-find')
+  assert.equal(pluginUrl('/anime-find', '/p7fco3lmrlo69rpziq5xl0uv'), '/p7fco3lmrlo69rpziq5xl0uv/anime-find')
+  assert.equal(
+    pluginUrl('/anime-find/cover?url=https%3A%2F%2Fmikanani.me%2Fx.jpg', '/p7fco3lmrlo69rpziq5xl0uv'),
+    '/p7fco3lmrlo69rpziq5xl0uv/anime-find/cover?url=https%3A%2F%2Fmikanani.me%2Fx.jpg',
+  )
+})


### PR DESCRIPTION
## 改动说明

在带路径前缀的反代后面（例如 `https://host:38012/p7fco3lmrlo69rpziq5xl0uv/`），客户端原先请求根路径 `/anime-find`，封面和详情会 404。

现在会从插件脚本地址或页面路径解析出前缀，把接口和封面请求发到 `/p7fco3lmrlo69rpziq5xl0uv/anime-find`。本地直接访问根路径时行为不变。

## 改动类型

- [x] Bug 修复
- [ ] 新功能或来源
- [ ] UI / 交互调整
- [ ] 重构
- [x] 测试或文档

## 验证

- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] 已在 Harness Web 中手动验证（如适用）
- [ ] UI 改动已附截图（如适用）

## 安全与隐私

- [x] 未包含密钥、Cookie、个人数据、私有网络信息或本地配置
- [x] 新增网络请求设置了超时，并能处理来源失败

## 关联 Issue


Made with [Cursor](https://cursor.com)