### PR TITLE
feature/streaming playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,14 @@ dsh plugin --profile web add /absolute/path/to/anime-find
 ### 流媒体播放
 
 流媒体默认关闭。打开 **设置 → 插件 → 插件配置 → 搜番**，开启「在线播放」后可粘贴规则
-JSON 数组，并单独启停每条规则。规则须为可静态解析的 CSS 选择器子集，至少包含
+JSON 数组，并单独启停每条规则。规则须为可静态解析的 CSS 或受限 XPath 子集，至少包含
 `name`、`baseURL`、`searchURL`、`searchList`、`searchName`、`searchResult`、`chapterRoads`
 和 `chapterResult`。`{{keyword}}` 或 `{{query}}` 会替换为搜索关键词。
 
 流媒体 Tab 只显示已解析出剧集的源；单集不能播放时可换源或打开源站。媒体请求仅会代理到
 已启用规则的域名（HLS playlist 会重写分片链接），不提供开放代理。首期不支持依赖
-Kazumi WebView 拦截的动态规则，也不会自动同步社区规则仓库。插件不托管任何内容，请仅
+Kazumi WebView 拦截的动态规则，也不会自动同步社区规则仓库。受限 XPath 支持常见的
+`//tag`、层级、序号、属性与属性包含谓词；脚本、函数和文本匹配谓词仍不支持。插件不托管任何内容，请仅
 访问你有权观看的内容并遵守来源站点条款。
 
 也可通过 `cordis.patch.yml` 设置默认来源：

--- a/README.md
+++ b/README.md
@@ -68,8 +68,26 @@ JSON 数组，并单独启停每条规则。规则须为可静态解析的 CSS �
 `name`、`baseURL`、`searchURL`、`searchList`、`searchName`、`searchResult`、`chapterRoads`
 和 `chapterResult`。`{{keyword}}` 或 `{{query}}` 会替换为搜索关键词。
 
+播放地址支持两种取法：`playURL` 既可以是指向 `src`/`href` 的选择器，也可以写成
+`script:player_aaaa.url`，从播放页内联脚本对象里读取（MacCMS 站点常用，按同级
+`encrypt` 字段自动处理 URL 编码或 base64）。
+
+当媒体位于站点之外的 CDN 时，用 `mediaHosts` 显式声明这些域名，只有声明过的域才会
+被解析和代理放行；私网、回环和链路本地地址始终拒绝。
+
+`mediaHeaders` 只作用于媒体请求，值留空表示不发送该头。同一站点的不同 CDN 要求可能
+相反（有的必须带 `Referer`，有的带了就报错），所以键名含点时视为域名，其下的头只对该
+域及其子域生效：
+
+```json
+{
+  "mediaHosts": ["cdn-a.example", "cdn-b.example"],
+  "mediaHeaders": { "cdn-b.example": { "referer": "" } }
+}
+```
+
 流媒体 Tab 只显示已解析出剧集的源；单集不能播放时可换源或打开源站。媒体请求仅会代理到
-已启用规则的域名（HLS playlist 会重写分片链接），不提供开放代理。首期不支持依赖
+已启用规则的域名及其声明的 `mediaHosts`（HLS playlist 会重写分片链接），不提供开放代理。首期不支持依赖
 Kazumi WebView 拦截的动态规则，也不会自动同步社区规则仓库。受限 XPath 支持常见的
 `//tag`、层级、序号、属性与属性包含谓词；脚本、函数和文本匹配谓词仍不支持。插件不托管任何内容，请仅
 访问你有权观看的内容并遵守来源站点条款。

--- a/README.md
+++ b/README.md
@@ -119,6 +119,37 @@ pnpm build
 
 源码位于 `src/`，构建结果输出到 `lib/`。`lib/` 不提交到版本库，安装或发布时由 `prepare` 脚本生成。
 
+### Harness + MiniMax 中国站验收
+
+使用隔离的 `DSH_HOME` 部署本地插件时，需要先为 Harness 注册模型提供方；否则 Web 首次引导无法创建会话，也无法触发 `anime_find_search` 和 ToolView。密钥只通过环境变量传入，不要写入仓库或 `settings.yaml`：
+
+```sh
+export MINIMAX_KEY_CN='...'
+export DSH_HOME="$(mktemp -d)"
+
+mkdir -p "$DSH_HOME"
+cat >"$DSH_HOME/settings.yaml" <<'EOF'
+llm-pi-ai:
+  providers:
+    minimax-cn:
+      apiKeyEnv: MINIMAX_KEY_CN
+      api: openai-completions
+      baseURL: https://api.minimaxi.com/v1
+      models:
+        - id: MiniMax-M3
+EOF
+
+npx @deepseek-ai/dsh web
+```
+
+随后在 **设置 → 模型** 选择 `minimax-cn / MiniMax-M3`，并从另一个终端安装本地插件：
+
+```sh
+DSH_HOME="$DSH_HOME" npx @deepseek-ai/dsh plugin --profile web add /absolute/path/to/anime-find
+```
+
+在新会话中请求搜番，确认工具视图的「流媒体」Tab、可播源卡片、选集和播放器路径。该配置仅用于验收；流媒体规则和任何第三方站点授权仍须由测试者自行提供。
+
 ## 故障排查
 
 - **页面停在 Loading plugins**：确认 `pnpm build` 成功，重启 `dsh web` 后强制刷新

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ DeepSeek Harness 搜番插件。在对话中搜索番剧，以可点击卡片展
 - 支持「还有吗」「换一批」等追问并分页展示更多结果
 - 点击卡片后按字幕组和集数浏览资源，并可查看 Bangumi 介绍、评分和短评
 - 支持复制磁力链接和打开 `.torrent` 文件
+- 可选流媒体 Tab：按搜索结果显示用户规则解析出的可播源，并在同页选集播放
 - 可在 Harness 插件设置中启用来源、调整结果数量和站点地址
 - 在插件设置中查看当前版本，并手动检查 GitHub 正式 Release
 
@@ -59,6 +60,18 @@ dsh plugin --profile web add /absolute/path/to/anime-find
 
 保存后立即生效。配置会写入 Harness 用户目录下的 `anime-find.json`。
 版本与安装来源为只读信息，不会写入该配置文件。
+
+### 流媒体播放
+
+流媒体默认关闭。打开 **设置 → 插件 → 插件配置 → 搜番**，开启「在线播放」后可粘贴规则
+JSON 数组，并单独启停每条规则。规则须为可静态解析的 CSS 选择器子集，至少包含
+`name`、`baseURL`、`searchURL`、`searchList`、`searchName`、`searchResult`、`chapterRoads`
+和 `chapterResult`。`{{keyword}}` 或 `{{query}}` 会替换为搜索关键词。
+
+流媒体 Tab 只显示已解析出剧集的源；单集不能播放时可换源或打开源站。媒体请求仅会代理到
+已启用规则的域名（HLS playlist 会重写分片链接），不提供开放代理。首期不支持依赖
+Kazumi WebView 拦截的动态规则，也不会自动同步社区规则仓库。插件不托管任何内容，请仅
+访问你有权观看的内容并遵守来源站点条款。
 
 也可通过 `cordis.patch.yml` 设置默认来源：
 

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ dsh plugin --profile web add /absolute/path/to/anime-find
 
 ### 流媒体播放
 
-流媒体默认关闭。打开 **设置 → 插件 → 插件配置 → 搜番**，开启「在线播放」后可粘贴规则
-JSON 数组，并单独启停每条规则。规则须为可静态解析的 CSS 或受限 XPath 子集，至少包含
+流媒体默认开启，并内置一条可静态解析的试点规则（xfdm）。打开 **设置 → 插件 → 插件配置 → 搜番**
+可关闭总开关、启停或替换规则 JSON。规则须为可静态解析的 CSS 或受限 XPath 子集，至少包含
 `name`、`baseURL`、`searchURL`、`searchList`、`searchName`、`searchResult`、`chapterRoads`
 和 `chapterResult`。`{{keyword}}` 或 `{{query}}` 会替换为搜索关键词。
 

--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -4,3 +4,26 @@
       config:
         sources:
           - mikan
+        streamEnabled: true
+        streamRules:
+          - id: xfdm
+            name: xfdm（试点源）
+            enabled: true
+            baseURL: https://dm1.xfdm.pro
+            searchURL: /search.html?wd={{keyword}}
+            searchList: div.public-list-box.search-box
+            searchName: .thumb-txt
+            searchResult: a.public-list-exp
+            chapterRoads: ul.anthology-list-play li
+            chapterResult: a
+            chapterName: a
+            playURL: script:player_aaaa.url
+            mediaHosts:
+              - xfvod.pro
+              - moedot.net
+              - pan.wo.cn
+            mediaHeaders:
+              moedot.net:
+                referer: ''
+              pan.wo.cn:
+                referer: ''

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json && mkdir -p lib/tests/fixtures && cp src/client.js lib/client.js && cp src/tests/fixtures/* lib/tests/fixtures/",
+    "build": "tsc -p tsconfig.json && mkdir -p lib/tests/fixtures && cp src/client.js lib/client.js && cp node_modules/hls.js/dist/hls.min.js lib/hls.min.js && cp src/tests/fixtures/* lib/tests/fixtures/",
     "prepare": "npm run build",
     "test": "npm run build && node --test lib/tests/*.test.js",
     "typecheck": "tsc -p tsconfig.json --noEmit"
@@ -62,7 +62,8 @@
     "react": "^18.2.0"
   },
   "dependencies": {
-    "cheerio": "^1.1.2"
+    "cheerio": "^1.1.2",
+    "hls.js": "^1.7.0"
   },
   "devDependencies": {
     "@deepseek-ai/cordis": "^4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  nth-check: ^2.1.1
+
 importers:
 
   .:
@@ -347,8 +350,8 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
-  nth-check@2.0.1:
-    resolution: {integrity: sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==}
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
   parse5-htmlparser2-tree-adapter@7.1.0:
     resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
@@ -595,7 +598,7 @@ snapshots:
       css-what: 6.1.0
       domhandler: 5.0.3
       domutils: 3.2.2
-      nth-check: 2.0.1
+      nth-check: 2.1.1
 
   css-what@6.1.0: {}
 
@@ -647,7 +650,7 @@ snapshots:
     dependencies:
       js-tokens: 3.0.0
 
-  nth-check@2.0.1:
+  nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       cheerio:
         specifier: ^1.1.2
         version: 1.2.0
+      hls.js:
+        specifier: ^1.7.0
+        version: 1.7.0
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -327,6 +330,9 @@ packages:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
+  hls.js@1.7.0:
+    resolution: {integrity: sha512-NnQpT6Z//+2IB2qovSUbKbrlXY1MOpi0JynZ9L2NNOuTJiNCyMSQj9k2laEj1v7CxU/Hb8oTWR98eT3mVpPQVQ==}
+
   htmlparser2@10.1.0:
     resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
 
@@ -621,6 +627,8 @@ snapshots:
   entities@6.0.0: {}
 
   entities@7.0.1: {}
+
+  hls.js@1.7.0: {}
 
   htmlparser2@10.1.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+# nth-check 2.0.1 ships no ESM entry, so css-select's ESM build resolves its
+# default import to the CJS namespace and throws "getNCheck is not a function"
+# for any :nth-of-type selector. Rules using positional XPath predicates hit
+# this at runtime.
+overrides:
+  nth-check: ^2.1.1

--- a/src/client.js
+++ b/src/client.js
@@ -783,13 +783,17 @@ window.__ModuleLoader__.load({
       const episodeIndex = episode ? ordered.findIndex((item) => item.id === episode.id) : -1;
       const previousEpisode = episodeIndex > 0 ? ordered[episodeIndex - 1] : null;
       const nextEpisode = episodeIndex >= 0 && episodeIndex < ordered.length - 1 ? ordered[episodeIndex + 1] : null;
-      const currentUrl = qualities[quality]?.url;
+      const currentQuality = qualities[quality];
+      const currentUrl = currentQuality?.url;
+      const isHls = currentQuality?.format === "hls";
       useEffect(() => {
         const video = videoRef.current;
-        if (!video || !currentUrl || !/\.m3u8(?:\?|$)/i.test(currentUrl)) return;
+        if (!video || !currentUrl || !isHls) return;
         let instance;
         const attach = () => {
           if (!window.Hls?.isSupported?.()) return;
+          video.removeAttribute("src");
+          video.load();
           instance = new window.Hls();
           instance.loadSource(pluginUrl(currentUrl));
           instance.attachMedia(video);
@@ -805,7 +809,7 @@ window.__ModuleLoader__.load({
           return () => { script.remove(); instance?.destroy?.(); };
         }
         return () => instance?.destroy?.();
-      }, [currentUrl]);
+      }, [currentUrl, isHls]);
       if (!config) return h(LoadingBody, { text: "正在读取流媒体设置…" });
       if (!config.streamEnabled) return h("div", { className: "af-stream-empty" }, "流媒体功能当前关闭。开启后仅导入你有权使用的规则。 ", h("a", { className: "af-more-link", href: pluginUrl("/settings/plugins") }, "打开插件设置"));
       if (!config.streamRules?.some((rule) => rule.enabled)) return h("div", { className: "af-stream-empty" }, "尚未启用流媒体规则。粘贴兼容的静态 CSS 或受限 XPath 子集规则。 ", h("a", { className: "af-more-link", href: pluginUrl("/settings/plugins") }, "打开插件设置"));
@@ -862,7 +866,7 @@ window.__ModuleLoader__.load({
             } }, "换一个源") : null,
           ),
           h("div", { className: "af-episodes" }, ordered.map((item) => h("button", { key: item.id, type: "button", "data-testid": "stream-episode", className: "af-episode" + (episode?.id === item.id ? " on" : ""), onClick: () => chooseEpisode(selected, item) }, item.name))),
-          currentUrl ? h("video", { ref: videoRef, className: "af-video", src: /\.m3u8(?:\?|$)/i.test(currentUrl) ? undefined : pluginUrl(currentUrl), controls: true, autoPlay: true, onError: () => setPlayError("播放器无法加载该集，可能受源站限制。你可以换源或在源站打开。") }) : null,
+          currentUrl ? h("video", { ref: videoRef, className: "af-video", src: isHls ? undefined : pluginUrl(currentUrl), controls: true, autoPlay: true, onError: () => setPlayError("播放器无法加载该集，可能受源站限制。你可以换源或在源站打开。") }) : null,
           playError ? h("div", { className: "af-player-error" }, playError) : !currentUrl ? h("div", { className: "af-player-error" }, "选择剧集以解析播放地址。") : null,
         ) : null,
       );

--- a/src/client.js
+++ b/src/client.js
@@ -804,7 +804,7 @@ window.__ModuleLoader__.load({
       }, [currentUrl]);
       if (!config) return h(LoadingBody, { text: "正在读取流媒体设置…" });
       if (!config.streamEnabled) return h("div", { className: "af-stream-empty" }, "流媒体功能当前关闭。请前往 设置 → 插件 → 搜番，开启后仅导入你有权使用的规则。");
-      if (!config.streamRules?.some((rule) => rule.enabled)) return h("div", { className: "af-stream-empty" }, "尚未启用流媒体规则。请前往 设置 → 插件 → 搜番，粘贴兼容的静态 CSS 规则。");
+      if (!config.streamRules?.some((rule) => rule.enabled)) return h("div", { className: "af-stream-empty" }, "尚未启用流媒体规则。请前往 设置 → 插件 → 搜番，粘贴兼容的静态 CSS 或受限 XPath 子集规则。");
       return h("div", null,
         h("div", { className: "af-stream-note" }, `流媒体已开启 · ${config.streamRules.filter((rule) => rule.enabled).length} 条规则启用中。仅显示已解析出剧集的源。`),
         loading ? h(LoadingBody, { text: "正在按当前搜索结果解析可播源…" }) : null,
@@ -1148,7 +1148,7 @@ window.__ModuleLoader__.load({
                 h("input", { type: "checkbox", checked: !!draft.streamEnabled, onChange: () => setDraft({ ...draft, streamEnabled: !draft.streamEnabled }) }),
                 "启用流媒体",
               ),
-              h("p", { className: "af-cfg-hint" }, "仅访问你有权观看的内容，并遵守源站条款。首期仅支持静态 CSS 解析规则，不支持 WebView 拦截。"),
+              h("p", { className: "af-cfg-hint" }, "仅访问你有权观看的内容，并遵守源站条款。首期支持静态 CSS 或受限 XPath 子集，不支持 WebView 拦截。"),
             ),
             h("div", { className: "af-cfg-f" },
               h("label", { htmlFor: "af-stream-rules" }, "流媒体规则 JSON"),

--- a/src/client.js
+++ b/src/client.js
@@ -151,6 +151,17 @@ window.__ModuleLoader__.load({
 .af-update-cmd{margin-top:5px;padding:10px 12px;border-radius:8px;background:var(--dsw-alias-toast-bg);color:var(--dsw-alias-label-primary-foreground);font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px;line-height:1.5;word-break:break-all}
 .af-update-actions{display:flex;align-items:center;gap:10px;margin-top:10px}
 .af-update-restart{margin:10px 0 0;color:var(--dsw-alias-label-tertiary);font-size:12px;line-height:1.5}
+.af-search-tabs{display:flex;gap:4px;border-bottom:1px solid var(--dsw-alias-border-l2);margin:0 0 12px}
+.af-search-tab{appearance:none;border:0;border-bottom:2px solid transparent;background:transparent;padding:9px 12px;cursor:pointer;color:var(--dsw-alias-label-caption);font:inherit;font-size:13px}
+.af-search-tab.on{color:var(--dsw-alias-brand-primary-new-colorprimary-new-color);border-bottom-color:var(--dsw-alias-brand-primary-new-colorprimary-new-color);font-weight:600}
+.af-stream-note,.af-stream-empty{border:1px solid var(--dsw-alias-border-l2);border-radius:10px;padding:11px 12px;margin:0 0 12px;font-size:12px;line-height:1.6;color:var(--dsw-alias-label-caption);background:var(--dsw-alias-bg-layer-2)}
+.af-stream-note{color:var(--dsw-alias-state-business-primary)}
+.af-stream-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:10px}
+.af-stream-card{border:1px solid var(--dsw-alias-border-l2);border-radius:12px;background:var(--dsw-alias-bg-layer-2);padding:12px;text-align:left;color:var(--dsw-alias-label-primary);font:inherit;cursor:pointer}
+.af-stream-card.on{border-color:var(--dsw-alias-brand-primary-new-colorprimary-new-color);box-shadow:0 0 0 2px var(--dsw-alias-button-ghost-active-fill)}
+.af-stream-card:hover{background:var(--dsw-alias-interactive-bg-hover)}
+.af-stream-title{font-weight:700;font-size:14px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.af-stream-rule{font-size:12px;color:var(--dsw-alias-label-tertiary);margin-top:4px}.af-stream-facts{font-size:12px;color:var(--dsw-alias-label-caption);margin-top:9px}
+.af-player-panel{margin-top:14px;border:1px solid var(--dsw-alias-border-l2);border-radius:12px;overflow:hidden;background:var(--dsw-alias-bg-layer-2)}.af-player-head{padding:12px;border-bottom:1px solid var(--dsw-alias-border-l2);font-size:13px;font-weight:600}.af-episodes{padding:12px;display:flex;gap:7px;flex-wrap:wrap}.af-episode{font:inherit;font-size:12px;padding:5px 9px;border-radius:7px;cursor:pointer;border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-layer-1);color:var(--dsw-alias-label-secondary)}.af-episode.on{background:var(--dsw-alias-button-primary-fill);color:var(--dsw-alias-label-primary-foreground);border-color:transparent}.af-video{display:block;width:100%;aspect-ratio:16/9;background:#0f172a}.af-player-actions{padding:10px 12px;display:flex;gap:8px;align-items:center;flex-wrap:wrap}.af-player-error{padding:14px;color:var(--dsw-alias-state-error-primary);font-size:12px;line-height:1.6}
 @media (max-width:560px){.af-update-compare{grid-template-columns:1fr}.af-update-arrow{display:none}}
 `;
 
@@ -733,6 +744,100 @@ window.__ModuleLoader__.load({
         || null;
     }
 
+    function StreamView({ items }) {
+      const [config, setConfig] = useState(null);
+      const [sources, setSources] = useState([]);
+      const [loading, setLoading] = useState(false);
+      const [error, setError] = useState("");
+      const [selected, setSelected] = useState(null);
+      const [episode, setEpisode] = useState(null);
+      const [qualities, setQualities] = useState([]);
+      const [quality, setQuality] = useState(0);
+      const [playError, setPlayError] = useState("");
+      const [reverse, setReverse] = useState(false);
+      const videoRef = React.useRef(null);
+      useEffect(() => {
+        let live = true;
+        api("config", {}).then((data) => { if (live) setConfig(data); }, () => { if (live) setError("无法读取流媒体设置"); });
+        return () => { live = false; };
+      }, []);
+      useEffect(() => {
+        if (!config?.streamEnabled || !config.streamRules?.some((rule) => rule.enabled)) return;
+        let live = true;
+        setLoading(true); setError("");
+        api("streamSearch", { items: items.map((item) => ({ title: item.title, nameOrig: item.nameOrig })) })
+          .then((data) => { if (live) setSources(data.sources || []); })
+          .catch((e) => { if (live) setError(e.message || "解析可播源失败"); })
+          .finally(() => { if (live) setLoading(false); });
+        return () => { live = false; };
+      }, [config?.streamEnabled, JSON.stringify(config?.streamRules || []), (items || []).map((item) => item.id).join(",")]);
+      const chooseEpisode = async (nextSource, nextEpisode) => {
+        setSelected(nextSource); setEpisode(nextEpisode); setQualities([]); setPlayError("");
+        try {
+          const data = await api("streamResolve", { source: nextSource, episode: nextEpisode });
+          setQualities(data.qualities || []); setQuality(0);
+        } catch (e) { setPlayError(e.message || "无法解析该集播放地址"); }
+      };
+      const ordered = selected ? [...selected.episodes].sort((a, b) => reverse ? b.name.localeCompare(a.name, "zh") : a.name.localeCompare(b.name, "zh")) : [];
+      const currentUrl = qualities[quality]?.url;
+      useEffect(() => {
+        const video = videoRef.current;
+        if (!video || !currentUrl || !/\.m3u8(?:\?|$)/i.test(currentUrl)) return;
+        let instance;
+        const attach = () => {
+          if (!window.Hls?.isSupported?.()) return;
+          instance = new window.Hls();
+          instance.loadSource(pluginUrl(currentUrl));
+          instance.attachMedia(video);
+          instance.on(window.Hls.Events.ERROR, (_event, data) => { if (data?.fatal) setPlayError("HLS 播放器无法加载该集；可尝试换源或在源站打开。"); });
+        };
+        if (window.Hls) attach();
+        else {
+          const script = document.createElement("script");
+          script.src = pluginUrl("/plugins/anime-find/hls.min.js");
+          script.onload = attach;
+          script.onerror = () => setPlayError("无法加载内置 HLS 播放器；请尝试换源或在源站打开。");
+          document.head.appendChild(script);
+          return () => { script.remove(); instance?.destroy?.(); };
+        }
+        return () => instance?.destroy?.();
+      }, [currentUrl]);
+      if (!config) return h(LoadingBody, { text: "正在读取流媒体设置…" });
+      if (!config.streamEnabled) return h("div", { className: "af-stream-empty" }, "流媒体功能当前关闭。请前往 设置 → 插件 → 搜番，开启后仅导入你有权使用的规则。");
+      if (!config.streamRules?.some((rule) => rule.enabled)) return h("div", { className: "af-stream-empty" }, "尚未启用流媒体规则。请前往 设置 → 插件 → 搜番，粘贴兼容的静态 CSS 规则。");
+      return h("div", null,
+        h("div", { className: "af-stream-note" }, `流媒体已开启 · ${config.streamRules.filter((rule) => rule.enabled).length} 条规则启用中。仅显示已解析出剧集的源。`),
+        loading ? h(LoadingBody, { text: "正在按当前搜索结果解析可播源…" }) : null,
+        error ? h("div", { className: "af-err" }, error) : null,
+        !loading && !error && !sources.length ? h("div", { className: "af-stream-empty" }, "当前结果没有可展示的可播源。解析失败的源不会显示；可调整规则后重试。") : null,
+        h("div", { className: "af-stream-grid" }, sources.map((source) => h("button", {
+          key: source.id, type: "button", className: "af-stream-card" + (selected?.id === source.id ? " on" : ""),
+          onClick: () => chooseEpisode(source, source.episodes[0]),
+        }, h("div", { className: "af-stream-title", title: source.animeTitle }, source.animeTitle),
+          h("div", { className: "af-stream-rule" }, `${source.ruleName} · ${source.lineName}`),
+          h("div", { className: "af-stream-facts" }, `${source.episodes.length} 集 · ${source.status === "limited" ? "部分集受限" : "可选集播放"}`),
+        ))),
+        selected ? h("section", { className: "af-player-panel" },
+          h("div", { className: "af-player-head" }, `${selected.animeTitle} · ${selected.lineName}`),
+          h("div", { className: "af-player-actions" },
+            h("button", { type: "button", className: "af-mini", onClick: () => setReverse(!reverse) }, reverse ? "正序" : "倒序"),
+            qualities.length > 1 ? h("select", { value: quality, onChange: (e) => setQuality(Number(e.target.value)) },
+              qualities.map((item, index) => h("option", { key: item.url, value: index }, item.label)),
+            ) : null,
+            episode ? h("a", { className: "af-mini", href: episode.pageUrl, target: "_blank", rel: "noreferrer" }, "在源站打开") : null,
+            playError ? h("button", { type: "button", className: "af-mini", onClick: () => {
+              const alternative = sources.find((source) => source.id !== selected.id && source.episodes.length);
+              if (alternative) chooseEpisode(alternative, alternative.episodes[Math.min(selected.episodes.indexOf(episode), alternative.episodes.length - 1)]);
+              else setPlayError("没有更多可用播放源；可在源站打开或切回资源标签使用磁力。");
+            } }, "换一个源") : null,
+          ),
+          h("div", { className: "af-episodes" }, ordered.map((item) => h("button", { key: item.id, type: "button", className: "af-episode" + (episode?.id === item.id ? " on" : ""), onClick: () => chooseEpisode(selected, item) }, item.name))),
+          currentUrl ? h("video", { ref: videoRef, className: "af-video", src: /\.m3u8(?:\?|$)/i.test(currentUrl) ? undefined : pluginUrl(currentUrl), controls: true, autoPlay: true, onError: () => setPlayError("播放器无法加载该集，可能受源站限制。你可以换源或在源站打开。") }) : null,
+          playError ? h("div", { className: "af-player-error" }, playError) : !currentUrl ? h("div", { className: "af-player-error" }, "选择剧集以解析播放地址。") : null,
+        ) : null,
+      );
+    }
+
     function SearchToolView(props) {
       useEffect(() => ensureCss(), []);
       const payload = pickPayload(props);
@@ -742,6 +847,7 @@ window.__ModuleLoader__.load({
       const running = !!(props?.block && !("kind" in props.block));
       const [fetched, setFetched] = useState(null);
       const [err, setErr] = useState("");
+      const [tab, setTab] = useState("resources");
       const { session, pendingId, openItem, prefetch, close } = useOpenDetail();
       useEffect(() => {
         if (fromTool || running || query.length < 2) return;
@@ -754,8 +860,14 @@ window.__ModuleLoader__.load({
       const items = fromTool || fetched || [];
       if (running || !items.length) return err ? h("div", { className: "af-err" }, err) : null;
       return h("div", { className: "af-root af-tool" },
-        h("div", { className: "af-hint" }, `点击卡片查看磁力 · ${items.length} 条`),
-        h(Cards, { items, pendingId, onOpen: openItem, onPrefetch: prefetch }),
+        h("div", { className: "af-search-tabs", role: "tablist" },
+          h("button", { type: "button", role: "tab", className: "af-search-tab" + (tab === "resources" ? " on" : ""), "aria-selected": tab === "resources", onClick: () => setTab("resources") }, "资源"),
+          h("button", { type: "button", role: "tab", className: "af-search-tab" + (tab === "stream" ? " on" : ""), "aria-selected": tab === "stream", onClick: () => setTab("stream") }, "流媒体"),
+        ),
+        tab === "resources" ? [
+          h("div", { key: "hint", className: "af-hint" }, `点击卡片查看磁力 · ${items.length} 条`),
+          h(Cards, { key: "cards", items, pendingId, onOpen: openItem, onPrefetch: prefetch }),
+        ] : h(StreamView, { items }),
         session ? h(Drawer, { item: session.item, detail: session.detail, meta: session.meta, loading: !!session.loading, metaLoading: !!session.metaLoading, onClose: close }) : null,
       );
     }
@@ -815,6 +927,9 @@ window.__ModuleLoader__.load({
         mikanHost: "https://mikanani.me",
         anibtHost: "https://anibt.net",
         gardenHost: "https://api.animes.garden",
+        streamEnabled: false,
+        streamRules: [],
+        streamRulesText: "[]",
       };
     }
 
@@ -885,6 +1000,9 @@ window.__ModuleLoader__.load({
               mikanHost: d.mikanHost || "https://mikanani.me",
               anibtHost: d.anibtHost || "https://anibt.net",
               gardenHost: d.gardenHost || "https://api.animes.garden",
+              streamEnabled: d.streamEnabled === true,
+              streamRules: Array.isArray(d.streamRules) ? d.streamRules : [],
+              streamRulesText: JSON.stringify(Array.isArray(d.streamRules) ? d.streamRules : [], null, 2),
             };
             setSaved(next);
             setDraft(next);
@@ -911,7 +1029,11 @@ window.__ModuleLoader__.load({
         setSaving(true);
         setErr("");
         try {
-          const d = await api("config", { save: true, ...draft });
+          let streamRules;
+          try { streamRules = JSON.parse(draft.streamRulesText || "[]"); } catch { throw new Error("流媒体规则必须是有效的 JSON 数组"); }
+          if (!Array.isArray(streamRules)) throw new Error("流媒体规则必须是 JSON 数组");
+          for (const rule of streamRules) await api("streamValidate", { rule });
+          const d = await api("config", { save: true, ...draft, streamRules });
           const next = {
             sources: d.sources || draft.sources,
             maxResults: d.maxResults,
@@ -919,6 +1041,9 @@ window.__ModuleLoader__.load({
             mikanHost: d.mikanHost,
             anibtHost: d.anibtHost,
             gardenHost: d.gardenHost,
+            streamEnabled: d.streamEnabled === true,
+            streamRules: d.streamRules || [],
+            streamRulesText: JSON.stringify(d.streamRules || [], null, 2),
           };
           setSaved(next);
           setDraft(next);
@@ -1016,6 +1141,23 @@ window.__ModuleLoader__.load({
                 value: draft.gardenHost,
                 onChange: (e) => setDraft({ ...draft, gardenHost: e.target.value }),
               }),
+            ),
+            h("div", { className: "af-cfg-f" },
+              h("label", null, "在线播放（默认关闭）"),
+              h("label", { className: "af-cfg-src" },
+                h("input", { type: "checkbox", checked: !!draft.streamEnabled, onChange: () => setDraft({ ...draft, streamEnabled: !draft.streamEnabled }) }),
+                "启用流媒体",
+              ),
+              h("p", { className: "af-cfg-hint" }, "仅访问你有权观看的内容，并遵守源站条款。首期仅支持静态 CSS 解析规则，不支持 WebView 拦截。"),
+            ),
+            h("div", { className: "af-cfg-f" },
+              h("label", { htmlFor: "af-stream-rules" }, "流媒体规则 JSON"),
+              h("textarea", {
+                id: "af-stream-rules", rows: 8, value: draft.streamRulesText,
+                style: { width: "100%", fontFamily: "ui-monospace,monospace", fontSize: "12px", borderRadius: "8px", padding: "8px", color: "inherit", background: "var(--dsw-alias-bg-layer-3)", border: "1px solid var(--dsw-alias-border-l2)" },
+                onChange: (e) => setDraft({ ...draft, streamRulesText: e.target.value }),
+              }),
+              h("p", { className: "af-cfg-hint" }, "每项需包含 name、baseURL、searchURL、searchList、searchName、searchResult、chapterRoads、chapterResult；保存前会校验。"),
             ),
             h(VersionBlock, { metadata, result: updateResult, checking: checkingUpdate, onCheck: checkUpdate, onCopy: copyUpdateCommand }),
             h("div", { className: "af-cfg-ft" },

--- a/src/client.js
+++ b/src/client.js
@@ -953,6 +953,28 @@ window.__ModuleLoader__.load({
       { id: "garden", label: "AnimeGarden" },
     ];
 
+    const DEFAULT_STREAM_RULES = [
+      {
+        id: "xfdm",
+        name: "xfdm（试点源）",
+        enabled: true,
+        baseURL: "https://dm1.xfdm.pro",
+        searchURL: "/search.html?wd={{keyword}}",
+        searchList: "div.public-list-box.search-box",
+        searchName: ".thumb-txt",
+        searchResult: "a.public-list-exp",
+        chapterRoads: "ul.anthology-list-play li",
+        chapterResult: "a",
+        chapterName: "a",
+        playURL: "script:player_aaaa.url",
+        mediaHosts: ["xfvod.pro", "moedot.net", "pan.wo.cn"],
+        mediaHeaders: {
+          "moedot.net": { referer: "" },
+          "pan.wo.cn": { referer: "" },
+        },
+      },
+    ];
+
     function emptyDraft() {
       return {
         sources: ["mikan"],
@@ -961,9 +983,9 @@ window.__ModuleLoader__.load({
         mikanHost: "https://mikanani.me",
         anibtHost: "https://anibt.net",
         gardenHost: "https://api.animes.garden",
-        streamEnabled: false,
-        streamRules: [],
-        streamRulesText: "[]",
+        streamEnabled: true,
+        streamRules: DEFAULT_STREAM_RULES,
+        streamRulesText: JSON.stringify(DEFAULT_STREAM_RULES, null, 2),
       };
     }
 
@@ -1192,12 +1214,12 @@ window.__ModuleLoader__.load({
               }),
             ),
             h("div", { className: "af-cfg-f" },
-              h("label", null, "在线播放（默认关闭）"),
+              h("label", null, "在线播放（默认开启）"),
               h("label", { className: "af-cfg-src" },
                 h("input", { type: "checkbox", checked: !!draft.streamEnabled, onChange: () => setDraft({ ...draft, streamEnabled: !draft.streamEnabled }) }),
                 "启用流媒体",
               ),
-              h("p", { className: "af-cfg-hint" }, "仅访问你有权观看的内容，并遵守源站条款。首期支持静态 CSS 或受限 XPath 子集，不支持 WebView 拦截。"),
+              h("p", { className: "af-cfg-hint" }, "仅访问你有权观看的内容，并遵守源站条款。默认内置一条静态试点规则，可关闭或替换。首期支持静态 CSS、受限 XPath 与 script: 取址，不支持 WebView 拦截。"),
             ),
             h("div", { className: "af-cfg-f" },
               h("label", { htmlFor: "af-stream-rules" }, "流媒体规则 JSON"),
@@ -1206,7 +1228,7 @@ window.__ModuleLoader__.load({
                 style: { width: "100%", fontFamily: "ui-monospace,monospace", fontSize: "12px", borderRadius: "8px", padding: "8px", color: "inherit", background: "var(--dsw-alias-bg-layer-3)", border: "1px solid var(--dsw-alias-border-l2)" },
                 onChange: (e) => setDraft({ ...draft, streamRulesText: e.target.value }),
               }),
-              h("p", { className: "af-cfg-hint" }, "每项需包含 name、baseURL、searchURL、searchList、searchName、searchResult、chapterRoads、chapterResult；保存前会校验。"),
+              h("p", { className: "af-cfg-hint" }, "每项需包含 name、baseURL、searchURL、searchList、searchName、searchResult、chapterRoads、chapterResult；可用 playURL: script:player_aaaa.url 与 mediaHosts。保存前会校验。"),
               parsedRules.length ? h("div", { className: "af-rule-list" }, parsedRules.map((rule, index) => h("div", { className: "af-rule-row", key: rule.id || `${rule.name}-${index}` },
                 h("label", null, h("input", { type: "checkbox", checked: rule.enabled !== false, onChange: () => toggleRule(index) }), rule.name || `未命名规则 ${index + 1}`),
                 h("button", { type: "button", className: "af-mini af-rule-delete", onClick: () => deleteRule(index) }, "删除"),

--- a/src/client.js
+++ b/src/client.js
@@ -157,10 +157,10 @@ window.__ModuleLoader__.load({
 .af-stream-note,.af-stream-empty{border:1px solid var(--dsw-alias-border-l2);border-radius:10px;padding:11px 12px;margin:0 0 12px;font-size:12px;line-height:1.6;color:var(--dsw-alias-label-caption);background:var(--dsw-alias-bg-layer-2)}
 .af-stream-note{color:var(--dsw-alias-state-business-primary)}
 .af-stream-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:10px}
-.af-stream-card{border:1px solid var(--dsw-alias-border-l2);border-radius:12px;background:var(--dsw-alias-bg-layer-2);padding:12px;text-align:left;color:var(--dsw-alias-label-primary);font:inherit;cursor:pointer}
-.af-stream-card.on{border-color:var(--dsw-alias-brand-primary-new-colorprimary-new-color);box-shadow:0 0 0 2px var(--dsw-alias-button-ghost-active-fill)}
-.af-stream-card:hover{background:var(--dsw-alias-interactive-bg-hover)}
-.af-stream-title{font-weight:700;font-size:14px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.af-stream-rule{font-size:12px;color:var(--dsw-alias-label-tertiary);margin-top:4px}.af-stream-facts{font-size:12px;color:var(--dsw-alias-label-caption);margin-top:9px}
+.af-stream-card{min-height:142px;display:flex;flex-direction:column;align-items:stretch;gap:10px;border:1px solid var(--dsw-alias-border-l2);border-radius:12px;background:var(--dsw-alias-bg-layer-2);padding:13px;text-align:left;color:var(--dsw-alias-label-primary);font:inherit;cursor:pointer;transition:border-color .16s,box-shadow .16s,transform .16s}
+.af-stream-card.on{border-color:var(--dsw-alias-brand-primary-new-colorprimary-new-color);box-shadow:0 0 0 2px var(--dsw-alias-button-ghost-active-fill);background:var(--dsw-alias-bg-layer-1)}
+.af-stream-card:hover{background:var(--dsw-alias-interactive-bg-hover);border-color:var(--dsw-alias-brand-primary-new-colorprimary-new-color);transform:translateY(-1px)}
+.af-stream-card-top{display:flex;align-items:flex-start;gap:8px;min-width:0}.af-stream-card-id{min-width:0;flex:1}.af-stream-title{font-weight:700;font-size:14px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.af-stream-rule{font-size:12px;color:var(--dsw-alias-label-tertiary);margin-top:4px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.af-stream-state{flex:none;border-radius:999px;padding:3px 7px;font-size:10px;font-weight:600;line-height:1.4;background:var(--dsw-alias-state-success-tertiary);color:var(--dsw-alias-state-success-primary)}.af-stream-state.limited{background:var(--dsw-alias-state-warn-tertiary);color:var(--dsw-alias-state-warn-label)}.af-stream-facts{font-size:12px;color:var(--dsw-alias-label-caption);margin:0}.af-stream-card-foot{border-top:1px solid var(--dsw-alias-border-l1);padding-top:9px;margin-top:auto;display:flex;align-items:center;justify-content:space-between;gap:8px;font-size:11px;color:var(--dsw-alias-label-tertiary)}.af-stream-card-go{color:var(--dsw-alias-brand-primary-new-colorprimary-new-color);font-weight:600;white-space:nowrap}
 .af-player-panel{margin-top:14px;border:1px solid var(--dsw-alias-border-l2);border-radius:12px;overflow:hidden;background:var(--dsw-alias-bg-layer-2)}.af-player-head{padding:12px;border-bottom:1px solid var(--dsw-alias-border-l2);font-size:13px;font-weight:600}.af-episodes{padding:12px;display:flex;gap:7px;flex-wrap:wrap}.af-episode{font:inherit;font-size:12px;padding:5px 9px;border-radius:7px;cursor:pointer;border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-layer-1);color:var(--dsw-alias-label-secondary)}.af-episode.on{background:var(--dsw-alias-button-primary-fill);color:var(--dsw-alias-label-primary-foreground);border-color:transparent}.af-video{display:block;width:100%;aspect-ratio:16/9;background:#0f172a}.af-player-actions{padding:10px 12px;display:flex;gap:8px;align-items:center;flex-wrap:wrap}.af-player-error{padding:14px;color:var(--dsw-alias-state-error-primary);font-size:12px;line-height:1.6}
 @media (max-width:560px){.af-update-compare{grid-template-columns:1fr}.af-update-arrow{display:none}}
 `;
@@ -810,13 +810,27 @@ window.__ModuleLoader__.load({
         loading ? h(LoadingBody, { text: "正在按当前搜索结果解析可播源…" }) : null,
         error ? h("div", { className: "af-err" }, error) : null,
         !loading && !error && !sources.length ? h("div", { className: "af-stream-empty" }, "当前结果没有可展示的可播源。解析失败的源不会显示；可调整规则后重试。") : null,
-        h("div", { className: "af-stream-grid" }, sources.map((source) => h("button", {
-          key: source.id, type: "button", className: "af-stream-card" + (selected?.id === source.id ? " on" : ""),
-          onClick: () => chooseEpisode(source, source.episodes[0]),
-        }, h("div", { className: "af-stream-title", title: source.animeTitle }, source.animeTitle),
-          h("div", { className: "af-stream-rule" }, `${source.ruleName} · ${source.lineName}`),
-          h("div", { className: "af-stream-facts" }, `${source.episodes.length} 集 · ${source.status === "limited" ? "部分集受限" : "可选集播放"}`),
-        ))),
+        h("div", { className: "af-stream-grid" }, sources.map((source) => {
+          const limited = source.status === "limited";
+          const active = selected?.id === source.id;
+          return h("button", {
+            key: source.id, type: "button", "data-testid": "stream-source-card",
+            className: "af-stream-card" + (active ? " on" : ""),
+            onClick: () => chooseEpisode(source, source.episodes[0]),
+          },
+          h("div", { className: "af-stream-card-top" },
+            h("div", { className: "af-stream-card-id" },
+              h("div", { className: "af-stream-title", title: source.animeTitle }, source.animeTitle),
+              h("div", { className: "af-stream-rule", title: `${source.ruleName} · ${source.lineName}` }, `${source.ruleName} · ${source.lineName}`),
+            ),
+            h("span", { className: "af-stream-state" + (limited ? " limited" : "") }, limited ? "部分集受限" : "可播放"),
+          ),
+          h("div", { className: "af-stream-facts" }, `${source.episodes.length} 集 · ${source.lineName}`),
+          h("div", { className: "af-stream-card-foot" },
+            h("span", null, active ? "当前播放源" : "已解析选集"),
+            h("span", { className: "af-stream-card-go" }, active ? "已选中" : "选集播放 ›"),
+          ));
+        })),
         selected ? h("section", { className: "af-player-panel" },
           h("div", { className: "af-player-head" }, `${selected.animeTitle} · ${selected.lineName}`),
           h("div", { className: "af-player-actions" },
@@ -831,7 +845,7 @@ window.__ModuleLoader__.load({
               else setPlayError("没有更多可用播放源；可在源站打开或切回资源标签使用磁力。");
             } }, "换一个源") : null,
           ),
-          h("div", { className: "af-episodes" }, ordered.map((item) => h("button", { key: item.id, type: "button", className: "af-episode" + (episode?.id === item.id ? " on" : ""), onClick: () => chooseEpisode(selected, item) }, item.name))),
+          h("div", { className: "af-episodes" }, ordered.map((item) => h("button", { key: item.id, type: "button", "data-testid": "stream-episode", className: "af-episode" + (episode?.id === item.id ? " on" : ""), onClick: () => chooseEpisode(selected, item) }, item.name))),
           currentUrl ? h("video", { ref: videoRef, className: "af-video", src: /\.m3u8(?:\?|$)/i.test(currentUrl) ? undefined : pluginUrl(currentUrl), controls: true, autoPlay: true, onError: () => setPlayError("播放器无法加载该集，可能受源站限制。你可以换源或在源站打开。") }) : null,
           playError ? h("div", { className: "af-player-error" }, playError) : !currentUrl ? h("div", { className: "af-player-error" }, "选择剧集以解析播放地址。") : null,
         ) : null,
@@ -861,8 +875,8 @@ window.__ModuleLoader__.load({
       if (running || !items.length) return err ? h("div", { className: "af-err" }, err) : null;
       return h("div", { className: "af-root af-tool" },
         h("div", { className: "af-search-tabs", role: "tablist" },
-          h("button", { type: "button", role: "tab", className: "af-search-tab" + (tab === "resources" ? " on" : ""), "aria-selected": tab === "resources", onClick: () => setTab("resources") }, "资源"),
-          h("button", { type: "button", role: "tab", className: "af-search-tab" + (tab === "stream" ? " on" : ""), "aria-selected": tab === "stream", onClick: () => setTab("stream") }, "流媒体"),
+          h("button", { type: "button", role: "tab", "data-testid": "resource-tab", className: "af-search-tab" + (tab === "resources" ? " on" : ""), "aria-selected": tab === "resources", onClick: () => setTab("resources") }, "资源"),
+          h("button", { type: "button", role: "tab", "data-testid": "stream-tab", className: "af-search-tab" + (tab === "stream" ? " on" : ""), "aria-selected": tab === "stream", onClick: () => setTab("stream") }, "流媒体"),
         ),
         tab === "resources" ? [
           h("div", { key: "hint", className: "af-hint" }, `点击卡片查看磁力 · ${items.length} 条`),

--- a/src/client.js
+++ b/src/client.js
@@ -161,7 +161,7 @@ window.__ModuleLoader__.load({
 .af-stream-card.on{border-color:var(--dsw-alias-brand-primary-new-colorprimary-new-color);box-shadow:0 0 0 2px var(--dsw-alias-button-ghost-active-fill);background:var(--dsw-alias-bg-layer-1)}
 .af-stream-card:hover{background:var(--dsw-alias-interactive-bg-hover);border-color:var(--dsw-alias-brand-primary-new-colorprimary-new-color);transform:translateY(-1px)}
 .af-stream-card-top{display:flex;align-items:flex-start;gap:8px;min-width:0}.af-stream-card-id{min-width:0;flex:1}.af-stream-title{font-weight:700;font-size:14px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.af-stream-rule{font-size:12px;color:var(--dsw-alias-label-tertiary);margin-top:4px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.af-stream-state{flex:none;border-radius:999px;padding:3px 7px;font-size:10px;font-weight:600;line-height:1.4;background:var(--dsw-alias-state-success-tertiary);color:var(--dsw-alias-state-success-primary)}.af-stream-state.limited{background:var(--dsw-alias-state-warn-tertiary);color:var(--dsw-alias-state-warn-label)}.af-stream-facts{font-size:12px;color:var(--dsw-alias-label-caption);margin:0}.af-stream-card-foot{border-top:1px solid var(--dsw-alias-border-l1);padding-top:9px;margin-top:auto;display:flex;align-items:center;justify-content:space-between;gap:8px;font-size:11px;color:var(--dsw-alias-label-tertiary)}.af-stream-card-go{color:var(--dsw-alias-brand-primary-new-colorprimary-new-color);font-weight:600;white-space:nowrap}
-.af-player-panel{margin-top:14px;border:1px solid var(--dsw-alias-border-l2);border-radius:12px;overflow:hidden;background:var(--dsw-alias-bg-layer-2)}.af-player-head{padding:12px;border-bottom:1px solid var(--dsw-alias-border-l2);font-size:13px;font-weight:600}.af-episodes{padding:12px;display:flex;gap:7px;flex-wrap:wrap}.af-episode{font:inherit;font-size:12px;padding:5px 9px;border-radius:7px;cursor:pointer;border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-layer-1);color:var(--dsw-alias-label-secondary)}.af-episode.on{background:var(--dsw-alias-button-primary-fill);color:var(--dsw-alias-label-primary-foreground);border-color:transparent}.af-video{display:block;width:100%;aspect-ratio:16/9;background:#0f172a}.af-player-actions{padding:10px 12px;display:flex;gap:8px;align-items:center;flex-wrap:wrap}.af-player-error{padding:14px;color:var(--dsw-alias-state-error-primary);font-size:12px;line-height:1.6}
+.af-player-panel{margin-top:14px;border:1px solid var(--dsw-alias-border-l2);border-radius:12px;overflow:hidden;background:var(--dsw-alias-bg-layer-2)}.af-player-head{padding:12px;border-bottom:1px solid var(--dsw-alias-border-l2);font-size:13px;font-weight:600}.af-episodes{padding:12px;display:flex;gap:7px;flex-wrap:wrap}.af-episode{font:inherit;font-size:12px;padding:5px 9px;border-radius:7px;cursor:pointer;border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-layer-1);color:var(--dsw-alias-label-secondary)}.af-episode.on{background:var(--dsw-alias-button-primary-fill);color:var(--dsw-alias-label-primary-foreground);border-color:transparent}.af-video{display:block;width:100%;aspect-ratio:16/9;background:#0f172a}.af-player-actions{padding:10px 12px;display:flex;gap:8px;align-items:center;flex-wrap:wrap}.af-player-actions button:disabled{cursor:not-allowed;opacity:.45}.af-player-error{padding:14px;color:var(--dsw-alias-state-error-primary);font-size:12px;line-height:1.6}
 @media (max-width:560px){.af-update-compare{grid-template-columns:1fr}.af-update-arrow{display:none}}
 `;
 
@@ -779,6 +779,9 @@ window.__ModuleLoader__.load({
         } catch (e) { setPlayError(e.message || "无法解析该集播放地址"); }
       };
       const ordered = selected ? [...selected.episodes].sort((a, b) => reverse ? b.name.localeCompare(a.name, "zh") : a.name.localeCompare(b.name, "zh")) : [];
+      const episodeIndex = episode ? ordered.findIndex((item) => item.id === episode.id) : -1;
+      const previousEpisode = episodeIndex > 0 ? ordered[episodeIndex - 1] : null;
+      const nextEpisode = episodeIndex >= 0 && episodeIndex < ordered.length - 1 ? ordered[episodeIndex + 1] : null;
       const currentUrl = qualities[quality]?.url;
       useEffect(() => {
         const video = videoRef.current;
@@ -835,6 +838,14 @@ window.__ModuleLoader__.load({
           h("div", { className: "af-player-head" }, `${selected.animeTitle} · ${selected.lineName}`),
           h("div", { className: "af-player-actions" },
             h("button", { type: "button", className: "af-mini", onClick: () => setReverse(!reverse) }, reverse ? "正序" : "倒序"),
+            h("button", {
+              type: "button", className: "af-mini", "data-testid": "stream-previous-episode",
+              disabled: !previousEpisode, onClick: () => { if (previousEpisode) chooseEpisode(selected, previousEpisode); },
+            }, "上一集"),
+            h("button", {
+              type: "button", className: "af-mini", "data-testid": "stream-next-episode",
+              disabled: !nextEpisode, onClick: () => { if (nextEpisode) chooseEpisode(selected, nextEpisode); },
+            }, "下一集"),
             qualities.length > 1 ? h("select", { value: quality, onChange: (e) => setQuality(Number(e.target.value)) },
               qualities.map((item, index) => h("option", { key: item.url, value: index }, item.label)),
             ) : null,

--- a/src/client.js
+++ b/src/client.js
@@ -120,6 +120,7 @@ window.__ModuleLoader__.load({
 .af-cfg-f label{font-size:13px;font-weight:500;color:var(--dsw-alias-label-secondary)}
 .af-cfg-f input[type=text],.af-cfg-f input[type=number]{border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-layer-3);color:var(--dsw-alias-label-primary);height:34px;font:inherit;border-radius:8px;padding:0 12px;font-size:13px}
 .af-cfg-hint{margin:0;color:var(--dsw-alias-label-caption);font-size:12px}
+.af-cfg-warning{margin:0;color:var(--dsw-alias-state-warn-label);font-size:12px;line-height:1.5}.af-rule-list{display:flex;flex-direction:column;gap:6px}.af-rule-row{display:flex;align-items:center;gap:8px;padding:8px;border:1px solid var(--dsw-alias-border-l1);border-radius:8px;font-size:12px}.af-rule-row label{display:flex;gap:6px;align-items:center;cursor:pointer;flex:1}.af-rule-delete{margin-left:auto;color:var(--dsw-alias-state-error-primary)}
 .af-cfg-src{display:flex;flex-wrap:wrap;gap:10px 16px}
 .af-cfg-src label{display:flex;gap:6px;align-items:center;font-weight:400;cursor:pointer}
 .af-cfg-ft{border-top:1px solid var(--dsw-alias-border-l2);justify-content:flex-end;gap:8px;padding:12px 0 4px;display:flex}
@@ -806,13 +807,17 @@ window.__ModuleLoader__.load({
         return () => instance?.destroy?.();
       }, [currentUrl]);
       if (!config) return h(LoadingBody, { text: "正在读取流媒体设置…" });
-      if (!config.streamEnabled) return h("div", { className: "af-stream-empty" }, "流媒体功能当前关闭。请前往 设置 → 插件 → 搜番，开启后仅导入你有权使用的规则。");
-      if (!config.streamRules?.some((rule) => rule.enabled)) return h("div", { className: "af-stream-empty" }, "尚未启用流媒体规则。请前往 设置 → 插件 → 搜番，粘贴兼容的静态 CSS 或受限 XPath 子集规则。");
+      if (!config.streamEnabled) return h("div", { className: "af-stream-empty" }, "流媒体功能当前关闭。开启后仅导入你有权使用的规则。 ", h("a", { className: "af-more-link", href: pluginUrl("/settings/plugins") }, "打开插件设置"));
+      if (!config.streamRules?.some((rule) => rule.enabled)) return h("div", { className: "af-stream-empty" }, "尚未启用流媒体规则。粘贴兼容的静态 CSS 或受限 XPath 子集规则。 ", h("a", { className: "af-more-link", href: pluginUrl("/settings/plugins") }, "打开插件设置"));
       return h("div", null,
         h("div", { className: "af-stream-note" }, `流媒体已开启 · ${config.streamRules.filter((rule) => rule.enabled).length} 条规则启用中。仅显示已解析出剧集的源。`),
         loading ? h(LoadingBody, { text: "正在按当前搜索结果解析可播源…" }) : null,
         error ? h("div", { className: "af-err" }, error) : null,
-        !loading && !error && !sources.length ? h("div", { className: "af-stream-empty" }, "当前结果没有可展示的可播源。解析失败的源不会显示；可调整规则后重试。") : null,
+        config.streamRules.some((rule) => rule.enabled && rule.useWebview) ? h("div", { className: "af-cfg-warning" }, "部分已启用规则依赖 WebView，当前 Web 插件会跳过它们；请改用静态 CSS 或受限 XPath 规则。") : null,
+        !loading && !error && !sources.length ? h("div", { className: "af-stream-empty" },
+          "当前结果没有可展示的可播源。解析失败的源不会显示；可调整规则后重试。 ",
+          h("a", { className: "af-more-link", href: pluginUrl("/settings/plugins") }, "打开插件设置"),
+        ) : null,
         h("div", { className: "af-stream-grid" }, sources.map((source) => {
           const limited = source.status === "limited";
           const active = selected?.id === source.id;
@@ -828,7 +833,7 @@ window.__ModuleLoader__.load({
             ),
             h("span", { className: "af-stream-state" + (limited ? " limited" : "") }, limited ? "部分集受限" : "可播放"),
           ),
-          h("div", { className: "af-stream-facts" }, `${source.episodes.length} 集 · ${source.lineName}`),
+          h("div", { className: "af-stream-facts" }, `${source.format === "hls" ? "HLS" : source.format === "mp4" ? "MP4" : "未知格式"} · ${source.episodes.length} 集 · ${source.lineName}`),
           h("div", { className: "af-stream-card-foot" },
             h("span", null, active ? "当前播放源" : "已解析选集"),
             h("span", { className: "af-stream-card-go" }, active ? "已选中" : "选集播放 ›"),
@@ -1013,6 +1018,7 @@ window.__ModuleLoader__.load({
       const [updateResult, setUpdateResult] = useState(null);
       const [checkingUpdate, setCheckingUpdate] = useState(false);
       const [updateToast, setUpdateToast] = useState("");
+      const [ruleWarnings, setRuleWarnings] = useState([]);
       useEffect(() => {
         let live = true;
         api("config", {})
@@ -1049,6 +1055,15 @@ window.__ModuleLoader__.load({
         if (!sources.length) return;
         setDraft({ ...draft, sources });
       };
+      const parsedRules = useMemo(() => {
+        try {
+          const rules = JSON.parse(draft.streamRulesText || "[]");
+          return Array.isArray(rules) ? rules : [];
+        } catch { return []; }
+      }, [draft.streamRulesText]);
+      const setRules = (rules) => setDraft({ ...draft, streamRules: rules, streamRulesText: JSON.stringify(rules, null, 2) });
+      const toggleRule = (index) => setRules(parsedRules.map((rule, i) => i === index ? { ...rule, enabled: !rule.enabled } : rule));
+      const deleteRule = (index) => setRules(parsedRules.filter((_rule, i) => i !== index));
       const save = async () => {
         if (!draft) return;
         setSaving(true);
@@ -1057,7 +1072,11 @@ window.__ModuleLoader__.load({
           let streamRules;
           try { streamRules = JSON.parse(draft.streamRulesText || "[]"); } catch { throw new Error("流媒体规则必须是有效的 JSON 数组"); }
           if (!Array.isArray(streamRules)) throw new Error("流媒体规则必须是 JSON 数组");
-          for (const rule of streamRules) await api("streamValidate", { rule });
+          const warnings = [];
+          for (const rule of streamRules) {
+            const result = await api("streamValidate", { rule });
+            if (result.warning) warnings.push(`${result.rule?.name || rule.name || "未命名规则"}：${result.warning}`);
+          }
           const d = await api("config", { save: true, ...draft, streamRules });
           const next = {
             sources: d.sources || draft.sources,
@@ -1072,6 +1091,7 @@ window.__ModuleLoader__.load({
           };
           setSaved(next);
           setDraft(next);
+          setRuleWarnings(warnings);
         } catch (e) {
           setErr(e.message || String(e));
         } finally {
@@ -1183,6 +1203,11 @@ window.__ModuleLoader__.load({
                 onChange: (e) => setDraft({ ...draft, streamRulesText: e.target.value }),
               }),
               h("p", { className: "af-cfg-hint" }, "每项需包含 name、baseURL、searchURL、searchList、searchName、searchResult、chapterRoads、chapterResult；保存前会校验。"),
+              parsedRules.length ? h("div", { className: "af-rule-list" }, parsedRules.map((rule, index) => h("div", { className: "af-rule-row", key: rule.id || `${rule.name}-${index}` },
+                h("label", null, h("input", { type: "checkbox", checked: rule.enabled !== false, onChange: () => toggleRule(index) }), rule.name || `未命名规则 ${index + 1}`),
+                h("button", { type: "button", className: "af-mini af-rule-delete", onClick: () => deleteRule(index) }, "删除"),
+              ))) : null,
+              ruleWarnings.map((warning) => h("p", { className: "af-cfg-warning", key: warning }, warning)),
             ),
             h(VersionBlock, { metadata, result: updateResult, checking: checkingUpdate, onCheck: checkUpdate, onCopy: copyUpdateCommand }),
             h("div", { className: "af-cfg-ft" },

--- a/src/config-store.ts
+++ b/src/config-store.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
-import { isPrivateOrLocalHost } from './streaming.js'
+import { isPrivateOrLocalHost, normalizeMediaHosts } from './streaming.js'
 import type { PluginConfig, SourceId, StreamRule } from './types.js'
 
 export const DEFAULT_SOURCES: SourceId[] = ['mikan']
@@ -28,7 +28,15 @@ export function publicConfig(cfg: PluginConfig): Omit<PluginConfig, 'userAgent'>
     maxResults: cfg.maxResults,
     sources: [...cfg.sources],
     streamEnabled: cfg.streamEnabled,
-    streamRules: cfg.streamRules.map((rule) => ({ ...rule, headers: rule.headers ? { ...rule.headers } : undefined })),
+    streamRules: cfg.streamRules.map((rule) => ({
+      ...rule,
+      mediaHosts: rule.mediaHosts ? [...rule.mediaHosts] : undefined,
+      headers: rule.headers ? { ...rule.headers } : undefined,
+      mediaHeaders: rule.mediaHeaders
+        ? Object.fromEntries(Object.entries(rule.mediaHeaders).map(([key, value]) =>
+          [key, typeof value === 'string' ? value : { ...value }]))
+        : undefined,
+    })),
   }
 }
 
@@ -105,11 +113,43 @@ function sanitizeStreamRule(raw: unknown, index: number): StreamRule | undefined
   for (const key of ['chapterName', 'playURL', 'playURLs'] as const) {
     if (typeof value[key] === 'string' && value[key].trim()) out[key] = value[key].trim()
   }
+  const mediaHosts = normalizeMediaHosts(value.mediaHosts)
+  if (mediaHosts.length) out.mediaHosts = mediaHosts
   if (value.useWebview === true) out.useWebview = true
-  if (value.headers && typeof value.headers === 'object' && !Array.isArray(value.headers)) {
-    out.headers = Object.fromEntries(Object.entries(value.headers).filter(([key, header]) =>
-      /^[a-z0-9-]{1,64}$/i.test(key) && typeof header === 'string' && header.length < 1024,
-    )) as Record<string, string>
-  }
+  const headers = sanitizeHeaders(value.headers)
+  if (headers) out.headers = headers
+  const mediaHeaders = sanitizeMediaHeaders(value.mediaHeaders)
+  if (mediaHeaders) out.mediaHeaders = mediaHeaders
   return out as unknown as StreamRule
+}
+
+function isHeaderName(key: string): boolean {
+  return /^[a-z0-9-]{1,64}$/i.test(key)
+}
+
+function isHeaderValue(value: unknown): value is string {
+  return typeof value === 'string' && value.length < 1024
+}
+
+function sanitizeHeaders(raw: unknown): Record<string, string> | undefined {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined
+  const out = Object.fromEntries(Object.entries(raw).filter(([key, header]) =>
+    isHeaderName(key) && isHeaderValue(header),
+  )) as Record<string, string>
+  return Object.keys(out).length ? out : undefined
+}
+
+function sanitizeMediaHeaders(raw: unknown): Record<string, string | Record<string, string>> | undefined {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined
+  const out: Record<string, string | Record<string, string>> = {}
+  for (const [key, value] of Object.entries(raw)) {
+    if (isHeaderName(key)) {
+      if (isHeaderValue(value)) out[key] = value
+      continue
+    }
+    const [host] = normalizeMediaHosts([key])
+    const nested = sanitizeHeaders(value)
+    if (host && nested) out[host] = nested
+  }
+  return Object.keys(out).length ? out : undefined
 }

--- a/src/config-store.ts
+++ b/src/config-store.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
+import { isPrivateOrLocalHost } from './streaming.js'
 import type { PluginConfig, SourceId, StreamRule } from './types.js'
 
 export const DEFAULT_SOURCES: SourceId[] = ['mikan']
@@ -94,7 +95,7 @@ function sanitizeStreamRule(raw: unknown, index: number): StreamRule | undefined
   }
   try {
     const parsed = new URL(String(out.baseURL))
-    if (!/^https?:$/.test(parsed.protocol)) return undefined
+    if (!/^https?:$/.test(parsed.protocol) || isPrivateOrLocalHost(parsed.hostname)) return undefined
     out.baseURL = parsed.origin
   } catch {
     return undefined

--- a/src/config-store.ts
+++ b/src/config-store.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
-import type { PluginConfig, SourceId } from './types.js'
+import type { PluginConfig, SourceId, StreamRule } from './types.js'
 
 export const DEFAULT_SOURCES: SourceId[] = ['mikan']
 
@@ -26,6 +26,8 @@ export function publicConfig(cfg: PluginConfig): Omit<PluginConfig, 'userAgent'>
     timeoutMs: cfg.timeoutMs,
     maxResults: cfg.maxResults,
     sources: [...cfg.sources],
+    streamEnabled: cfg.streamEnabled,
+    streamRules: cfg.streamRules.map((rule) => ({ ...rule, headers: rule.headers ? { ...rule.headers } : undefined })),
   }
 }
 
@@ -55,6 +57,8 @@ export function sanitizePatch(raw: Record<string, unknown>): Partial<PluginConfi
   const max = Number(raw.maxResults)
   if (Number.isFinite(max) && max >= 1) out.maxResults = Math.min(Math.floor(max), 80)
   if (raw.sources !== undefined) out.sources = sanitizeSources(raw.sources)
+  if (typeof raw.streamEnabled === 'boolean') out.streamEnabled = raw.streamEnabled
+  if (raw.streamRules !== undefined) out.streamRules = sanitizeStreamRules(raw.streamRules)
   return out
 }
 
@@ -66,5 +70,45 @@ export function assignConfig(live: PluginConfig, patch: Partial<PluginConfig>): 
   if (patch.timeoutMs != null) live.timeoutMs = patch.timeoutMs
   if (patch.maxResults != null) live.maxResults = patch.maxResults
   if (patch.sources?.length) live.sources = [...patch.sources]
+  if (patch.streamEnabled != null) live.streamEnabled = patch.streamEnabled
+  if (patch.streamRules) live.streamRules = patch.streamRules.map((rule) => ({ ...rule }))
   return live
+}
+
+export function sanitizeStreamRules(raw: unknown): StreamRule[] {
+  if (!Array.isArray(raw)) return []
+  return raw
+    .slice(0, 20)
+    .map((value, index) => sanitizeStreamRule(value, index))
+    .filter((value): value is StreamRule => !!value)
+}
+
+function sanitizeStreamRule(raw: unknown, index: number): StreamRule | undefined {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined
+  const value = raw as Record<string, unknown>
+  const strings = ['name', 'baseURL', 'searchURL', 'searchList', 'searchName', 'searchResult', 'chapterRoads', 'chapterResult'] as const
+  const out: Record<string, unknown> = {}
+  for (const key of strings) {
+    if (typeof value[key] !== 'string' || !value[key].trim()) return undefined
+    out[key] = value[key].trim()
+  }
+  try {
+    const parsed = new URL(String(out.baseURL))
+    if (!/^https?:$/.test(parsed.protocol)) return undefined
+    out.baseURL = parsed.origin
+  } catch {
+    return undefined
+  }
+  out.id = typeof value.id === 'string' && value.id.trim() ? value.id.trim().slice(0, 80) : `rule-${index + 1}-${Date.now()}`
+  out.enabled = value.enabled !== false
+  for (const key of ['chapterName', 'playURL', 'playURLs'] as const) {
+    if (typeof value[key] === 'string' && value[key].trim()) out[key] = value[key].trim()
+  }
+  if (value.useWebview === true) out.useWebview = true
+  if (value.headers && typeof value.headers === 'object' && !Array.isArray(value.headers)) {
+    out.headers = Object.fromEntries(Object.entries(value.headers).filter(([key, header]) =>
+      /^[a-z0-9-]{1,64}$/i.test(key) && typeof header === 'string' && header.length < 1024,
+    )) as Record<string, string>
+  }
+  return out as unknown as StreamRule
 }

--- a/src/config-store.ts
+++ b/src/config-store.ts
@@ -6,6 +6,32 @@ import type { PluginConfig, SourceId, StreamRule } from './types.js'
 
 export const DEFAULT_SOURCES: SourceId[] = ['mikan']
 
+/**
+ * Bundled pilot rule for static MacCMS-style sites. Users can disable or replace
+ * it; the plugin still does not host or redistribute media itself.
+ */
+export const DEFAULT_STREAM_RULES: StreamRule[] = [
+  {
+    id: 'xfdm',
+    name: 'xfdm（试点源）',
+    enabled: true,
+    baseURL: 'https://dm1.xfdm.pro',
+    searchURL: '/search.html?wd={{keyword}}',
+    searchList: 'div.public-list-box.search-box',
+    searchName: '.thumb-txt',
+    searchResult: 'a.public-list-exp',
+    chapterRoads: 'ul.anthology-list-play li',
+    chapterResult: 'a',
+    chapterName: 'a',
+    playURL: 'script:player_aaaa.url',
+    mediaHosts: ['xfvod.pro', 'moedot.net', 'pan.wo.cn'],
+    mediaHeaders: {
+      'moedot.net': { referer: '' },
+      'pan.wo.cn': { referer: '' },
+    },
+  },
+]
+
 const ALLOWED: SourceId[] = ['mikan', 'anibt', 'garden']
 
 export function overlayPath(): string {

--- a/src/host.ts
+++ b/src/host.ts
@@ -25,7 +25,7 @@ export const Config: Schema<Config> = Schema.object({
   maxResults: Schema.number().default(12).description('搜索结果上限'),
   sources: Schema.array(Schema.union(['mikan', 'anibt', 'garden'] as const)).default(['mikan']).description('启用的搜索源，默认仅 Mikan'),
   streamEnabled: Schema.boolean().default(false).description('启用用户导入规则的流媒体在线播放'),
-  streamRules: Schema.array(Schema.object({})).default([]).description('用户导入的流媒体规则（静态 CSS 解析子集）'),
+  streamRules: Schema.array(Schema.object({})).default([]).description('用户导入的流媒体规则（静态 CSS 或受限 XPath 子集）'),
 }) as unknown as Schema<Config>
 
 export function apply(ctx: Context, config: Config): void {

--- a/src/host.ts
+++ b/src/host.ts
@@ -1,3 +1,4 @@
+import { readFile } from 'node:fs/promises'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import type { Context } from '@deepseek-ai/cordis'
 import { defineTool } from '@deepseek-ai/dsh-tools'
@@ -95,6 +96,9 @@ export function apply(ctx: Context, config: Config): void {
     server.register({ kind: 'exact', path: '/anime-find', handler: (req, res) => handleApi(req, res, cfg) })
     server.register({ kind: 'exact', path: '/anime-find/cover', handler: (req, res) => handleCover(req, res, cfg) })
     server.register({ kind: 'exact', path: '/anime-find/media', handler: (req, res) => handleMedia(req, res, cfg) })
+    // DSH only exposes the declared client entry automatically. Serve hls.js explicitly
+    // so the ToolView can load the package asset at /plugins/anime-find/hls.min.js.
+    server.register({ kind: 'exact', path: '/plugins/anime-find/hls.min.js', handler: (_req, res) => handleHlsAsset(res) })
   })
 }
 
@@ -283,6 +287,20 @@ async function handleCover(req: IncomingMessage, res: ServerResponse, cfg: Plugi
   } catch (err) {
     res.statusCode = 502
     res.end(err instanceof Error ? err.message : 'cover failed')
+  }
+}
+
+export async function handleHlsAsset(res: ServerResponse): Promise<void> {
+  try {
+    const asset = await readFile(new URL('./hls.min.js', import.meta.url))
+    res.statusCode = 200
+    res.setHeader('content-type', 'text/javascript; charset=utf-8')
+    res.setHeader('cache-control', 'public, max-age=3600')
+    res.setHeader('content-length', asset.byteLength)
+    res.end(asset)
+  } catch {
+    res.statusCode = 500
+    res.end('hls.js asset is unavailable; rebuild the anime-find plugin')
   }
 }
 

--- a/src/host.ts
+++ b/src/host.ts
@@ -8,7 +8,7 @@ import { enrichCardsWithBangumi, loadBangumiMeta } from './bangumi.js'
 import { fetchBytes } from './http.js'
 import { detailAnime, isSeasonBrowse, searchAnime } from './search.js'
 import { parseSeasonHint } from './season.js'
-import { aggregateStreams, isAllowedStreamUrl, resolveStream, validateRule } from './streaming.js'
+import { aggregateStreams, fetchAllowedStream, isAllowedStreamUrl, resolveStream, validateRule } from './streaming.js'
 import type { PluginConfig, SearchResult, SourceId, AnimeCard, StreamEpisode, StreamSource } from './types.js'
 import { checkForUpdate, getVersionMetadata } from './update-check.js'
 
@@ -314,14 +314,10 @@ export async function handleMedia(req: IncomingMessage, res: ServerResponse, cfg
       res.end('stream target is not allowed')
       return
     }
-    const headers = new Headers({
-      'user-agent': cfg.userAgent,
-      referer: rule.baseURL,
-    })
+    const headers = new Headers()
     const range = req.headers.range
     if (range) headers.set('range', range)
-    for (const [key, value] of Object.entries(rule.headers || {})) headers.set(key, value)
-    const upstream = await fetch(target, { headers, redirect: 'follow' })
+    const upstream = await fetchAllowedStream(target, rule, cfg, { headers })
     if (!upstream.ok && upstream.status !== 206) {
       res.statusCode = upstream.status
       res.end(`upstream HTTP ${upstream.status}`)
@@ -338,11 +334,11 @@ export async function handleMedia(req: IncomingMessage, res: ServerResponse, cfg
       const playlist = await upstream.text()
       const rewritten = playlist.replace(/^(?!#)(.+)$/gm, (line) => {
         try {
-          return `/anime-find/media?url=${encodeURIComponent(new URL(line.trim(), target).toString())}`
+          return `/anime-find/media?url=${encodeURIComponent(new URL(line.trim(), upstream.url || target).toString())}`
         } catch { return line }
       }).replace(/(URI=")([^"]+)(")/g, (_all, before, uri, after) => {
         try {
-          return `${before}/anime-find/media?url=${encodeURIComponent(new URL(uri, target).toString())}${after}`
+          return `${before}/anime-find/media?url=${encodeURIComponent(new URL(uri, upstream.url || target).toString())}${after}`
         } catch { return _all }
       })
       res.setHeader('content-type', 'application/vnd.apple.mpegurl; charset=utf-8')

--- a/src/host.ts
+++ b/src/host.ts
@@ -1,5 +1,7 @@
 import { readFile } from 'node:fs/promises'
 import type { IncomingMessage, ServerResponse } from 'node:http'
+import { Readable } from 'node:stream'
+import { pipeline } from 'node:stream/promises'
 import type { Context } from '@deepseek-ai/cordis'
 import { defineTool } from '@deepseek-ai/dsh-tools'
 import Schema from '@deepseek-ai/schemastery'
@@ -350,10 +352,9 @@ export async function handleMedia(req: IncomingMessage, res: ServerResponse, cfg
     }
     res.setHeader('content-type', contentType || 'application/octet-stream')
     if (!upstream.body) throw new Error('upstream body is empty')
-    const body = Buffer.from(await upstream.arrayBuffer())
     const contentLength = upstream.headers.get('content-length')
     if (contentLength) res.setHeader('content-length', contentLength)
-    res.end(body)
+    await pipeline(Readable.fromWeb(upstream.body as unknown as import('node:stream/web').ReadableStream), res)
   } catch (err) {
     res.statusCode = 502
     res.end(err instanceof Error ? err.message : 'media proxy failed')

--- a/src/host.ts
+++ b/src/host.ts
@@ -7,7 +7,8 @@ import { enrichCardsWithBangumi, loadBangumiMeta } from './bangumi.js'
 import { fetchBytes } from './http.js'
 import { detailAnime, isSeasonBrowse, searchAnime } from './search.js'
 import { parseSeasonHint } from './season.js'
-import type { PluginConfig, SearchResult, SourceId, AnimeCard } from './types.js'
+import { aggregateStreams, isAllowedStreamUrl, resolveStream, validateRule } from './streaming.js'
+import type { PluginConfig, SearchResult, SourceId, AnimeCard, StreamEpisode, StreamSource } from './types.js'
 import { checkForUpdate, getVersionMetadata } from './update-check.js'
 
 export const name = 'anime-find'
@@ -23,7 +24,9 @@ export const Config: Schema<Config> = Schema.object({
   userAgent: Schema.string().default('Mozilla/5.0 (compatible; anime-find/0.1)').description('请求 UA'),
   maxResults: Schema.number().default(12).description('搜索结果上限'),
   sources: Schema.array(Schema.union(['mikan', 'anibt', 'garden'] as const)).default(['mikan']).description('启用的搜索源，默认仅 Mikan'),
-})
+  streamEnabled: Schema.boolean().default(false).description('启用用户导入规则的流媒体在线播放'),
+  streamRules: Schema.array(Schema.object({})).default([]).description('用户导入的流媒体规则（静态 CSS 解析子集）'),
+}) as unknown as Schema<Config>
 
 export function apply(ctx: Context, config: Config): void {
   const cfg = withDefaults(config)
@@ -91,6 +94,7 @@ export function apply(ctx: Context, config: Config): void {
     const server = (c as unknown as { webServer: { register: (route: { kind: string; path: string; handler: (req: IncomingMessage, res: ServerResponse) => void | Promise<void> }) => void } }).webServer
     server.register({ kind: 'exact', path: '/anime-find', handler: (req, res) => handleApi(req, res, cfg) })
     server.register({ kind: 'exact', path: '/anime-find/cover', handler: (req, res) => handleCover(req, res, cfg) })
+    server.register({ kind: 'exact', path: '/anime-find/media', handler: (req, res) => handleMedia(req, res, cfg) })
   })
 }
 
@@ -103,6 +107,8 @@ function withDefaults(config: Config): PluginConfig {
     userAgent: config.userAgent || 'Mozilla/5.0 (compatible; anime-find/0.1)',
     maxResults: config.maxResults || 12,
     sources: (config.sources?.length ? sanitizeSources(config.sources) : ['mikan']) as SourceId[],
+    streamEnabled: config.streamEnabled === true,
+    streamRules: Array.isArray(config.streamRules) ? config.streamRules : [],
   }
 }
 
@@ -217,6 +223,35 @@ async function handleApi(req: IncomingMessage, res: ServerResponse, cfg: PluginC
       }
       return sendJson(res, 200, { ok: true, ...publicConfig(cfg), ...getVersionMetadata() })
     }
+    if (method === 'streamValidate') {
+      const { rule, warning } = validateRule(body.rule)
+      return sendJson(res, 200, { ok: true, rule, warning })
+    }
+    if (method === 'streamSearch') {
+      const items = Array.isArray(body.items)
+        ? body.items.filter((item): item is { title?: string; nameOrig?: string } => !!item && typeof item === 'object').slice(0, 12)
+        : []
+      if (!cfg.streamEnabled) return sendJson(res, 200, { ok: true, sources: [], state: 'disabled' })
+      if (!cfg.streamRules.some((rule) => rule.enabled)) return sendJson(res, 200, { ok: true, sources: [], state: 'noRules' })
+      const sources = await aggregateStreams(items, cfg)
+      return sendJson(res, 200, { ok: true, sources, state: 'ready' })
+    }
+    if (method === 'streamResolve') {
+      const source = body.source as StreamSource
+      const episode = body.episode as StreamEpisode
+      if (!source?.ruleId || !episode?.pageUrl) return sendJson(res, 400, { ok: false, error: '缺少播放源或剧集' })
+      const rule = cfg.streamRules.find((item) => item.id === source.ruleId && item.enabled)
+      if (!rule) return sendJson(res, 404, { ok: false, error: '播放规则不存在或已关闭' })
+      const qualities = await resolveStream(source, episode, rule, cfg)
+      return sendJson(res, 200, {
+        ok: true,
+        qualities: qualities.map((quality) => ({
+          ...quality,
+          url: `/anime-find/media?url=${encodeURIComponent(quality.url)}`,
+        })),
+        sourceUrl: source.sourceUrl,
+      })
+    }
     if (method === 'checkUpdate') {
       const metadata = getVersionMetadata()
       const result = await checkForUpdate(metadata, {
@@ -248,5 +283,60 @@ async function handleCover(req: IncomingMessage, res: ServerResponse, cfg: Plugi
   } catch (err) {
     res.statusCode = 502
     res.end(err instanceof Error ? err.message : 'cover failed')
+  }
+}
+
+async function handleMedia(req: IncomingMessage, res: ServerResponse, cfg: PluginConfig): Promise<void> {
+  try {
+    const requestUrl = new URL(req.url || '/', 'http://127.0.0.1')
+    const target = requestUrl.searchParams.get('url') || ''
+    const rule = isAllowedStreamUrl(target, cfg)
+    if (!rule) {
+      res.statusCode = 403
+      res.end('stream target is not allowed')
+      return
+    }
+    const headers = new Headers({
+      'user-agent': cfg.userAgent,
+      referer: rule.baseURL,
+    })
+    const range = req.headers.range
+    if (range) headers.set('range', range)
+    for (const [key, value] of Object.entries(rule.headers || {})) headers.set(key, value)
+    const upstream = await fetch(target, { headers, redirect: 'follow' })
+    if (!upstream.ok && upstream.status !== 206) {
+      res.statusCode = upstream.status
+      res.end(`upstream HTTP ${upstream.status}`)
+      return
+    }
+    const contentType = upstream.headers.get('content-type') || ''
+    res.statusCode = upstream.status
+    for (const name of ['content-length', 'content-range', 'accept-ranges']) {
+      const value = upstream.headers.get(name)
+      if (value) res.setHeader(name, value)
+    }
+    res.setHeader('cache-control', 'no-store')
+    if (/mpegurl|m3u8/i.test(contentType) || /\.m3u8(?:\?|$)/i.test(target)) {
+      const playlist = await upstream.text()
+      const rewritten = playlist.replace(/^(?!#)(.+)$/gm, (line) => {
+        try {
+          return `/anime-find/media?url=${encodeURIComponent(new URL(line.trim(), target).toString())}`
+        } catch { return line }
+      }).replace(/(URI=")([^"]+)(")/g, (_all, before, uri, after) => {
+        try {
+          return `${before}/anime-find/media?url=${encodeURIComponent(new URL(uri, target).toString())}${after}`
+        } catch { return _all }
+      })
+      res.setHeader('content-type', 'application/vnd.apple.mpegurl; charset=utf-8')
+      res.end(rewritten)
+      return
+    }
+    res.setHeader('content-type', contentType || 'application/octet-stream')
+    if (!upstream.body) throw new Error('upstream body is empty')
+    const body = Buffer.from(await upstream.arrayBuffer())
+    res.end(body)
+  } catch (err) {
+    res.statusCode = 502
+    res.end(err instanceof Error ? err.message : 'media proxy failed')
   }
 }

--- a/src/host.ts
+++ b/src/host.ts
@@ -319,7 +319,7 @@ export async function handleMedia(req: IncomingMessage, res: ServerResponse, cfg
     const headers = new Headers()
     const range = req.headers.range
     if (range) headers.set('range', range)
-    const upstream = await fetchAllowedStream(target, rule, cfg, { headers })
+    const upstream = await fetchAllowedStream(target, rule, cfg, { headers }, 'media')
     if (!upstream.ok && upstream.status !== 206) {
       res.statusCode = upstream.status
       res.end(`upstream HTTP ${upstream.status}`)

--- a/src/host.ts
+++ b/src/host.ts
@@ -286,7 +286,7 @@ async function handleCover(req: IncomingMessage, res: ServerResponse, cfg: Plugi
   }
 }
 
-async function handleMedia(req: IncomingMessage, res: ServerResponse, cfg: PluginConfig): Promise<void> {
+export async function handleMedia(req: IncomingMessage, res: ServerResponse, cfg: PluginConfig): Promise<void> {
   try {
     const requestUrl = new URL(req.url || '/', 'http://127.0.0.1')
     const target = requestUrl.searchParams.get('url') || ''
@@ -311,7 +311,7 @@ async function handleMedia(req: IncomingMessage, res: ServerResponse, cfg: Plugi
     }
     const contentType = upstream.headers.get('content-type') || ''
     res.statusCode = upstream.status
-    for (const name of ['content-length', 'content-range', 'accept-ranges']) {
+    for (const name of ['content-range', 'accept-ranges']) {
       const value = upstream.headers.get(name)
       if (value) res.setHeader(name, value)
     }
@@ -328,12 +328,17 @@ async function handleMedia(req: IncomingMessage, res: ServerResponse, cfg: Plugi
         } catch { return _all }
       })
       res.setHeader('content-type', 'application/vnd.apple.mpegurl; charset=utf-8')
+      // Playlist URLs are expanded into local proxy URLs, so the upstream length
+      // is invalid and would make Node truncate the rewritten response.
+      res.setHeader('content-length', Buffer.byteLength(rewritten))
       res.end(rewritten)
       return
     }
     res.setHeader('content-type', contentType || 'application/octet-stream')
     if (!upstream.body) throw new Error('upstream body is empty')
     const body = Buffer.from(await upstream.arrayBuffer())
+    const contentLength = upstream.headers.get('content-length')
+    if (contentLength) res.setHeader('content-length', contentLength)
     res.end(body)
   } catch (err) {
     res.statusCode = 502

--- a/src/host.ts
+++ b/src/host.ts
@@ -5,7 +5,7 @@ import { pipeline } from 'node:stream/promises'
 import type { Context } from '@deepseek-ai/cordis'
 import { defineTool } from '@deepseek-ai/dsh-tools'
 import Schema from '@deepseek-ai/schemastery'
-import { assignConfig, publicConfig, readOverlay, sanitizePatch, sanitizeSources, writeOverlay } from './config-store.js'
+import { assignConfig, DEFAULT_STREAM_RULES, publicConfig, readOverlay, sanitizePatch, sanitizeSources, writeOverlay } from './config-store.js'
 import { enrichCardsWithBangumi, loadBangumiMeta } from './bangumi.js'
 import { fetchBytes } from './http.js'
 import { detailAnime, isSeasonBrowse, searchAnime } from './search.js'
@@ -27,8 +27,8 @@ export const Config: Schema<Config> = Schema.object({
   userAgent: Schema.string().default('Mozilla/5.0 (compatible; anime-find/0.1)').description('请求 UA'),
   maxResults: Schema.number().default(12).description('搜索结果上限'),
   sources: Schema.array(Schema.union(['mikan', 'anibt', 'garden'] as const)).default(['mikan']).description('启用的搜索源，默认仅 Mikan'),
-  streamEnabled: Schema.boolean().default(false).description('启用用户导入规则的流媒体在线播放'),
-  streamRules: Schema.array(Schema.object({})).default([]).description('用户导入的流媒体规则（静态 CSS 或受限 XPath 子集）'),
+  streamEnabled: Schema.boolean().default(true).description('启用流媒体在线播放（内置试点规则，可关闭或替换）'),
+  streamRules: Schema.array(Schema.object({})).default(DEFAULT_STREAM_RULES).description('流媒体规则（静态 CSS / 受限 XPath / script: 取址；默认含一条试点源）'),
 }) as unknown as Schema<Config>
 
 export function apply(ctx: Context, config: Config): void {
@@ -113,8 +113,10 @@ function withDefaults(config: Config): PluginConfig {
     userAgent: config.userAgent || 'Mozilla/5.0 (compatible; anime-find/0.1)',
     maxResults: config.maxResults || 12,
     sources: (config.sources?.length ? sanitizeSources(config.sources) : ['mikan']) as SourceId[],
-    streamEnabled: config.streamEnabled === true,
-    streamRules: Array.isArray(config.streamRules) ? config.streamRules : [],
+    streamEnabled: config.streamEnabled !== false,
+    streamRules: Array.isArray(config.streamRules) && config.streamRules.length
+      ? config.streamRules
+      : DEFAULT_STREAM_RULES.map((rule) => structuredClone(rule)),
   }
 }
 

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -1,0 +1,131 @@
+import * as cheerio from 'cheerio'
+import { createHash } from 'node:crypto'
+import type { PluginConfig, StreamEpisode, StreamQuality, StreamRule, StreamSource } from './types.js'
+
+const MAX_SOURCES = 24
+const MAX_EPISODES = 120
+
+function id(...parts: string[]): string {
+  return createHash('sha256').update(parts.join('\0')).digest('hex').slice(0, 24)
+}
+
+function absolute(base: string, value: string): string {
+  return new URL(value, base).toString()
+}
+
+function selector(rule: string, field: string): string {
+  const value = String(rule || '').trim()
+  if (!value || value.startsWith('//')) throw new Error(`${field} 必须是 CSS 选择器；XPath 与 WebView 规则暂不支持`)
+  return value
+}
+
+async function getHtml(url: string, cfg: PluginConfig, rule?: StreamRule): Promise<string> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), Math.min(cfg.timeoutMs, 15000))
+  try {
+    const headers = new Headers({
+      'user-agent': cfg.userAgent,
+      accept: 'text/html,application/xhtml+xml',
+      referer: rule?.baseURL || new URL(url).origin,
+    })
+    for (const [key, value] of Object.entries(rule?.headers || {})) headers.set(key, value)
+    const res = await fetch(url, { headers, signal: controller.signal, redirect: 'follow' })
+    if (!res.ok) throw new Error(`源站返回 HTTP ${res.status}`)
+    return await res.text()
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+function formatFrom(url: string): 'hls' | 'mp4' | 'unknown' {
+  const clean = url.split('?')[0].toLowerCase()
+  return clean.endsWith('.m3u8') ? 'hls' : clean.endsWith('.mp4') ? 'mp4' : 'unknown'
+}
+
+export function validateRule(raw: unknown): { rule: StreamRule; warning?: string } {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) throw new Error('规则必须是 JSON 对象')
+  const rule = raw as StreamRule
+  const required = ['name', 'baseURL', 'searchURL', 'searchList', 'searchName', 'searchResult', 'chapterRoads', 'chapterResult'] as const
+  for (const key of required) if (!String(rule[key] || '').trim()) throw new Error(`规则缺少必要字段：${key}`)
+  if (!/^https?:\/\//i.test(rule.baseURL)) throw new Error('baseURL 必须是 http 或 https 地址')
+  for (const key of ['searchList', 'searchName', 'searchResult', 'chapterRoads', 'chapterResult'] as const) selector(String(rule[key]), key)
+  return { rule, warning: rule.useWebview ? '该规则声明 useWebview；仅静态 CSS 解析可用，部分剧集可能无法播放。' : undefined }
+}
+
+export async function aggregateStreams(items: Array<{ title?: string; nameOrig?: string }>, cfg: PluginConfig): Promise<StreamSource[]> {
+  if (!cfg.streamEnabled) return []
+  const rules = cfg.streamRules.filter((rule) => rule.enabled)
+  if (!rules.length) return []
+  const tasks = items.slice(0, 12).flatMap((item) => rules.map((rule) => searchRule(item.title || item.nameOrig || '', rule, cfg)))
+  const settled = await Promise.allSettled(tasks)
+  return settled.flatMap((result) => result.status === 'fulfilled' ? result.value : []).slice(0, MAX_SOURCES)
+}
+
+async function searchRule(title: string, rule: StreamRule, cfg: PluginConfig): Promise<StreamSource[]> {
+  if (!title || rule.useWebview) return []
+  const searchUrl = absolute(rule.baseURL, rule.searchURL.replace(/\{\{\s*(?:keyword|query)\s*\}\}/gi, encodeURIComponent(title)))
+  const $ = cheerio.load(await getHtml(searchUrl, cfg, rule))
+  const rows = $(selector(rule.searchList, 'searchList')).toArray().slice(0, 5)
+  const result: StreamSource[] = []
+  for (const row of rows) {
+    const nameNode = $(row).find(selector(rule.searchName, 'searchName')).first()
+    const urlNode = $(row).find(selector(rule.searchResult, 'searchResult')).first()
+    const name = nameNode.text().trim() || $(row).text().trim()
+    const href = urlNode.attr('href') || $(row).attr('href')
+    if (!href || !name) continue
+    const sourceUrl = absolute(searchUrl, href)
+    const episodes = await parseEpisodes(sourceUrl, rule, cfg)
+    if (!episodes.length) continue
+    result.push({
+      id: id(rule.id, sourceUrl),
+      animeTitle: title,
+      ruleId: rule.id,
+      ruleName: rule.name,
+      lineName: name.slice(0, 80),
+      sourceUrl,
+      episodes,
+      status: 'ready',
+    })
+  }
+  return result
+}
+
+async function parseEpisodes(sourceUrl: string, rule: StreamRule, cfg: PluginConfig): Promise<StreamEpisode[]> {
+  const $ = cheerio.load(await getHtml(sourceUrl, cfg, rule))
+  return $(selector(rule.chapterRoads, 'chapterRoads')).toArray().slice(0, MAX_EPISODES).flatMap((node, index) => {
+    const target = rule.chapterResult ? $(node).find(selector(rule.chapterResult, 'chapterResult')).first() : $(node)
+    const href = target.attr('href') || $(node).attr('href')
+    if (!href) return []
+    const name = rule.chapterName ? $(node).find(selector(rule.chapterName, 'chapterName')).first().text().trim() : ''
+    return [{ id: id(rule.id, sourceUrl, String(index), href), name: name || target.text().trim() || `第 ${index + 1} 集`, pageUrl: absolute(sourceUrl, href) }]
+  })
+}
+
+export async function resolveStream(source: StreamSource, episode: StreamEpisode, rule: StreamRule, cfg: PluginConfig): Promise<StreamQuality[]> {
+  if (!rule.enabled || !cfg.streamEnabled) throw new Error('流媒体功能或规则已关闭')
+  const html = await getHtml(episode.pageUrl, cfg, rule)
+  const $ = cheerio.load(html)
+  const urls = rule.playURLs
+    ? $(selector(rule.playURLs, 'playURLs')).toArray().map((node) => String($(node).attr('href') || $(node).attr('src') || '').trim())
+    : [rule.playURL ? $(selector(rule.playURL, 'playURL')).first().attr('src') || $(selector(rule.playURL, 'playURL')).first().attr('href') || '' : '']
+  const qualities = urls.filter(Boolean).map((value, index) => {
+    const url = absolute(episode.pageUrl, value)
+    const format = formatFrom(url)
+    return { label: index === 0 ? '自动' : `线路 ${index + 1}`, url, format }
+  }).filter((quality): quality is StreamQuality => quality.format !== 'unknown')
+  if (!qualities.length) throw new Error('该集未解析出 MP4 或 HLS 播放地址')
+  return qualities
+}
+
+export function isAllowedStreamUrl(target: string, cfg: PluginConfig): StreamRule | undefined {
+  let url: URL
+  try { url = new URL(target) } catch { return undefined }
+  if (!/^https?:$/.test(url.protocol) || !cfg.streamEnabled) return undefined
+  return cfg.streamRules.find((rule) => {
+    if (!rule.enabled) return false
+    try {
+      const base = new URL(rule.baseURL)
+      return url.hostname === base.hostname || url.hostname.endsWith(`.${base.hostname}`)
+    } catch { return false }
+  })
+}

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -6,6 +6,10 @@ const MAX_SOURCES = 24
 const MAX_EPISODES = 120
 const STREAM_CONCURRENCY = 4
 const MAX_REDIRECTS = 5
+const SCRIPT_PREFIX = 'script:'
+
+/** Page fetches stay on the rule's own site; media may also use rule.mediaHosts. */
+export type AllowKind = 'page' | 'media'
 
 function id(...parts: string[]): string {
   return createHash('sha256').update(parts.join('\0')).digest('hex').slice(0, 24)
@@ -68,17 +72,23 @@ export async function fetchAllowedStream(
   rule: StreamRule,
   cfg: PluginConfig,
   init: RequestInit = {},
+  kind: AllowKind = 'page',
 ): Promise<Response> {
   let current = url
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), Math.min(cfg.timeoutMs, 15000))
   try {
-    const headers = new Headers(init.headers)
-    headers.set('user-agent', cfg.userAgent)
-    headers.set('referer', rule.baseURL)
-    for (const [key, value] of Object.entries(rule.headers || {})) headers.set(key, value)
     for (let redirects = 0; redirects <= MAX_REDIRECTS; redirects++) {
-      if (!isAllowedForRule(current, rule)) throw new Error('流媒体地址不在当前规则允许域内')
+      if (!isAllowedForRule(current, rule, kind)) throw new Error('流媒体地址不在当前规则允许域内')
+      // Recomputed per hop: a redirect can land on a CDN with different header
+      // requirements than the host that issued it.
+      const headers = new Headers(init.headers)
+      headers.set('user-agent', cfg.userAgent)
+      headers.set('referer', rule.baseURL)
+      for (const [key, value] of Object.entries(requestHeaderOverrides(rule, current, kind))) {
+        if (value === '') headers.delete(key)
+        else headers.set(key, value)
+      }
       const res = await fetch(current, { ...init, headers, signal: controller.signal, redirect: 'manual' })
       if (![301, 302, 303, 307, 308].includes(res.status)) return res
       const location = res.headers.get('location')
@@ -89,6 +99,29 @@ export async function fetchAllowedStream(
   } finally {
     clearTimeout(timer)
   }
+}
+
+/**
+ * Flattens rule headers for one request. In `mediaHeaders`, a key containing a
+ * dot is treated as a host whose nested map applies only to that host and its
+ * subdomains; header names never contain dots. An empty value drops the header,
+ * which matters because some CDNs reject a request that carries a Referer while
+ * others need one to honour Range.
+ */
+export function requestHeaderOverrides(rule: StreamRule, target: string, kind: AllowKind): Record<string, string> {
+  const out: Record<string, string> = { ...rule.headers }
+  if (kind !== 'media') return out
+  let hostname = ''
+  try { hostname = new URL(target).hostname.toLowerCase() } catch { /* keep global overrides only */ }
+  for (const [key, value] of Object.entries(rule.mediaHeaders || {})) {
+    if (typeof value === 'string') {
+      if (!key.includes('.')) out[key] = value
+      continue
+    }
+    const host = key.toLowerCase()
+    if (hostname === host || hostname.endsWith(`.${host}`)) Object.assign(out, value)
+  }
+  return out
 }
 
 async function getHtml(url: string, cfg: PluginConfig, rule?: StreamRule): Promise<string> {
@@ -106,6 +139,54 @@ async function getHtml(url: string, cfg: PluginConfig, rule?: StreamRule): Promi
 function formatFrom(url: string): 'hls' | 'mp4' | 'unknown' {
   const clean = url.split('?')[0].toLowerCase()
   return clean.endsWith('.m3u8') ? 'hls' : clean.endsWith('.mp4') ? 'mp4' : 'unknown'
+}
+
+/**
+ * Reads a media URL out of an inline script object, e.g. `player_aaaa.url` for
+ * MacCMS pages that assign `var player_aaaa={"url":"https:\/\/...m3u8",...}`.
+ * MacCMS marks the encoding of `url` with a sibling `encrypt` field.
+ */
+export function extractScriptValue(html: string, expression: string): string {
+  const [variable, ...path] = expression.split('.').map((part) => part.trim()).filter(Boolean)
+  if (!variable || !path.length) throw new Error('playURL 的 script: 表达式需形如 script:变量名.字段名')
+  const start = html.indexOf(`${variable}=`)
+  const brace = start < 0 ? -1 : html.indexOf('{', start)
+  if (brace < 0) throw new Error(`播放页未找到脚本变量 ${variable}`)
+
+  let depth = 0
+  let inString = false
+  let escaped = false
+  let end = -1
+  for (let i = brace; i < html.length; i++) {
+    const char = html[i]
+    if (escaped) { escaped = false; continue }
+    if (char === '\\') { escaped = true; continue }
+    if (char === '"') { inString = !inString; continue }
+    if (inString) continue
+    if (char === '{') depth++
+    else if (char === '}' && --depth === 0) { end = i + 1; break }
+  }
+  if (end < 0) throw new Error(`脚本变量 ${variable} 不是完整的 JSON 对象`)
+
+  let value: unknown
+  try {
+    value = JSON.parse(html.slice(brace, end))
+  } catch {
+    throw new Error(`脚本变量 ${variable} 不是合法 JSON`)
+  }
+  const root = value as Record<string, unknown>
+  for (const key of path) {
+    if (!value || typeof value !== 'object') throw new Error(`脚本变量 ${variable} 缺少字段 ${path.join('.')}`)
+    value = (value as Record<string, unknown>)[key]
+  }
+  if (typeof value !== 'string' || !value) throw new Error(`脚本变量 ${variable} 缺少字段 ${path.join('.')}`)
+  return decodeMacCmsUrl(value, Number(root.encrypt) || 0)
+}
+
+function decodeMacCmsUrl(value: string, encrypt: number): string {
+  if (encrypt === 1) return decodeURIComponent(value)
+  if (encrypt === 2) return decodeURIComponent(Buffer.from(value, 'base64').toString('utf8'))
+  return value
 }
 
 export function validateRule(raw: unknown): { rule: StreamRule; warning?: string } {
@@ -192,28 +273,38 @@ export async function resolveStream(source: StreamSource, episode: StreamEpisode
   }
   const html = await getHtml(episode.pageUrl, cfg, rule)
   const $ = cheerio.load(html)
-  const urls = rule.playURLs
-    ? $(selector(rule.playURLs, 'playURLs')).toArray().map((node) => String($(node).attr('href') || $(node).attr('src') || '').trim())
-    : [rule.playURL ? $(selector(rule.playURL, 'playURL')).first().attr('src') || $(selector(rule.playURL, 'playURL')).first().attr('href') || '' : '']
+  const urls = rule.playURL?.startsWith(SCRIPT_PREFIX)
+    ? [extractScriptValue(html, rule.playURL.slice(SCRIPT_PREFIX.length))]
+    : rule.playURLs
+      ? $(selector(rule.playURLs, 'playURLs')).toArray().map((node) => String($(node).attr('href') || $(node).attr('src') || '').trim())
+      : [rule.playURL ? $(selector(rule.playURL, 'playURL')).first().attr('src') || $(selector(rule.playURL, 'playURL')).first().attr('href') || '' : '']
   const qualities = urls.filter(Boolean).map((value, index) => {
     const url = absolute(episode.pageUrl, value)
     const format = formatFrom(url)
     return { label: index === 0 ? '自动' : `线路 ${index + 1}`, url, format }
-  }).filter((quality): quality is StreamQuality => quality.format !== 'unknown' && isAllowedForRule(quality.url, rule))
+  }).filter((quality): quality is StreamQuality => quality.format !== 'unknown' && isAllowedForRule(quality.url, rule, 'media'))
   if (!qualities.length) throw new Error('该集未解析出 MP4 或 HLS 播放地址')
   return qualities
 }
 
-export function isAllowedForRule(target: string, rule: StreamRule): boolean {
+export function isAllowedForRule(target: string, rule: StreamRule, kind: AllowKind = 'page'): boolean {
   try {
     const url = new URL(target)
-    const base = new URL(rule.baseURL)
-    return /^https?:$/.test(url.protocol) &&
-      !isPrivateOrLocalHost(url.hostname) &&
-      (url.hostname === base.hostname || url.hostname.endsWith(`.${base.hostname}`))
+    if (!/^https?:$/.test(url.protocol) || isPrivateOrLocalHost(url.hostname)) return false
+    const hosts = [new URL(rule.baseURL).hostname]
+    if (kind === 'media') hosts.push(...normalizeMediaHosts(rule.mediaHosts))
+    return hosts.some((host) => url.hostname === host || url.hostname.endsWith(`.${host}`))
   } catch {
     return false
   }
+}
+
+export function normalizeMediaHosts(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return []
+  return raw
+    .map((value) => String(value).trim().toLowerCase())
+    .filter((host) => /^[a-z0-9.-]{1,253}$/.test(host) && host.includes('.') && !isPrivateOrLocalHost(host))
+    .slice(0, 10)
 }
 
 export function isPrivateOrLocalHost(hostname: string): boolean {
@@ -240,6 +331,6 @@ export function isAllowedStreamUrl(target: string, cfg: PluginConfig): StreamRul
   if (!/^https?:$/.test(url.protocol) || !cfg.streamEnabled) return undefined
   return cfg.streamRules.find((rule) => {
     if (!rule.enabled) return false
-    return isAllowedForRule(url.toString(), rule)
+    return isAllowedForRule(url.toString(), rule, 'media')
   })
 }

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -4,6 +4,8 @@ import type { PluginConfig, StreamEpisode, StreamQuality, StreamRule, StreamSour
 
 const MAX_SOURCES = 24
 const MAX_EPISODES = 120
+const STREAM_CONCURRENCY = 4
+const MAX_REDIRECTS = 5
 
 function id(...parts: string[]): string {
   return createHash('sha256').update(parts.join('\0')).digest('hex').slice(0, 24)
@@ -61,23 +63,44 @@ function selector(rule: string, field: string): string {
   return value.startsWith('//') ? xpathToCss(value, field) : value
 }
 
-async function getHtml(url: string, cfg: PluginConfig, rule?: StreamRule): Promise<string> {
-  if (rule && !isAllowedForRule(url, rule)) throw new Error('流媒体地址不在当前规则允许域内')
+export async function fetchAllowedStream(
+  url: string,
+  rule: StreamRule,
+  cfg: PluginConfig,
+  init: RequestInit = {},
+): Promise<Response> {
+  let current = url
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), Math.min(cfg.timeoutMs, 15000))
   try {
-    const headers = new Headers({
-      'user-agent': cfg.userAgent,
-      accept: 'text/html,application/xhtml+xml',
-      referer: rule?.baseURL || new URL(url).origin,
-    })
-    for (const [key, value] of Object.entries(rule?.headers || {})) headers.set(key, value)
-    const res = await fetch(url, { headers, signal: controller.signal, redirect: 'follow' })
-    if (!res.ok) throw new Error(`源站返回 HTTP ${res.status}`)
-    return await res.text()
+    const headers = new Headers(init.headers)
+    headers.set('user-agent', cfg.userAgent)
+    headers.set('referer', rule.baseURL)
+    for (const [key, value] of Object.entries(rule.headers || {})) headers.set(key, value)
+    for (let redirects = 0; redirects <= MAX_REDIRECTS; redirects++) {
+      if (!isAllowedForRule(current, rule)) throw new Error('流媒体地址不在当前规则允许域内')
+      const res = await fetch(current, { ...init, headers, signal: controller.signal, redirect: 'manual' })
+      if (![301, 302, 303, 307, 308].includes(res.status)) return res
+      const location = res.headers.get('location')
+      if (!location) throw new Error('源站重定向缺少地址')
+      current = new URL(location, current).toString()
+    }
+    throw new Error(`源站重定向超过 ${MAX_REDIRECTS} 次`)
   } finally {
     clearTimeout(timer)
   }
+}
+
+async function getHtml(url: string, cfg: PluginConfig, rule?: StreamRule): Promise<string> {
+  if (!rule) throw new Error('缺少流媒体规则')
+  const res = await fetchAllowedStream(url, rule, cfg, {
+    headers: {
+      'user-agent': cfg.userAgent,
+      accept: 'text/html,application/xhtml+xml',
+    },
+  })
+  if (!res.ok) throw new Error(`源站返回 HTTP ${res.status}`)
+  return await res.text()
 }
 
 function formatFrom(url: string): 'hls' | 'mp4' | 'unknown' {
@@ -99,9 +122,26 @@ export async function aggregateStreams(items: Array<{ title?: string; nameOrig?:
   if (!cfg.streamEnabled) return []
   const rules = cfg.streamRules.filter((rule) => rule.enabled)
   if (!rules.length) return []
-  const tasks = items.slice(0, 12).flatMap((item) => rules.map((rule) => searchRule(item.title || item.nameOrig || '', rule, cfg)))
-  const settled = await Promise.allSettled(tasks)
+  const tasks = items.slice(0, 12).flatMap((item) => rules.map((rule) => () => searchRule(item.title || item.nameOrig || '', rule, cfg)))
+  const settled = await runWithConcurrency(tasks, STREAM_CONCURRENCY)
   return settled.flatMap((result) => result.status === 'fulfilled' ? result.value : []).slice(0, MAX_SOURCES)
+}
+
+export async function runWithConcurrency<T>(tasks: Array<() => Promise<T>>, limit: number): Promise<PromiseSettledResult<T>[]> {
+  const results: PromiseSettledResult<T>[] = new Array(tasks.length)
+  let next = 0
+  const worker = async () => {
+    while (next < tasks.length) {
+      const index = next++
+      try {
+        results[index] = { status: 'fulfilled', value: await tasks[index]() }
+      } catch (reason) {
+        results[index] = { status: 'rejected', reason }
+      }
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(Math.max(limit, 1), tasks.length) }, worker))
+  return results
 }
 
 async function searchRule(title: string, rule: StreamRule, cfg: PluginConfig): Promise<StreamSource[]> {
@@ -127,7 +167,8 @@ async function searchRule(title: string, rule: StreamRule, cfg: PluginConfig): P
       lineName: name.slice(0, 80),
       sourceUrl,
       episodes,
-      status: 'ready',
+      format: 'unknown',
+      status: rule.playURL || rule.playURLs ? 'ready' : 'limited',
     })
   }
   return result
@@ -168,10 +209,24 @@ export function isAllowedForRule(target: string, rule: StreamRule): boolean {
     const url = new URL(target)
     const base = new URL(rule.baseURL)
     return /^https?:$/.test(url.protocol) &&
+      !isPrivateOrLocalHost(url.hostname) &&
       (url.hostname === base.hostname || url.hostname.endsWith(`.${base.hostname}`))
   } catch {
     return false
   }
+}
+
+function isPrivateOrLocalHost(hostname: string): boolean {
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, '')
+  if (host === 'localhost' || host.endsWith('.localhost') || host === '::1' || host.startsWith('fe80:') || host.startsWith('fc') || host.startsWith('fd')) return true
+  const ipv4 = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/)
+  if (!ipv4) return false
+  const octets = ipv4.slice(1).map(Number)
+  if (octets.some((part) => part > 255)) return true
+  return octets[0] === 0 || octets[0] === 10 || octets[0] === 127 ||
+    (octets[0] === 169 && octets[1] === 254) ||
+    (octets[0] === 172 && octets[1] >= 16 && octets[1] <= 31) ||
+    (octets[0] === 192 && octets[1] === 168)
 }
 
 export function isAllowedStreamUrl(target: string, cfg: PluginConfig): StreamRule | undefined {

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -216,10 +216,15 @@ export function isAllowedForRule(target: string, rule: StreamRule): boolean {
   }
 }
 
-function isPrivateOrLocalHost(hostname: string): boolean {
+export function isPrivateOrLocalHost(hostname: string): boolean {
   const host = hostname.toLowerCase().replace(/^\[|\]$/g, '')
   if (host === 'localhost' || host.endsWith('.localhost') || host === '::1' || host.startsWith('fe80:') || host.startsWith('fc') || host.startsWith('fd')) return true
-  const ipv4 = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/)
+  const mappedDottedIpv4 = host.match(/^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/)
+  const mappedHexIpv4 = host.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/)
+  const mappedIpv4 = mappedDottedIpv4?.[1] || (mappedHexIpv4
+    ? `${parseInt(mappedHexIpv4[1], 16) >> 8}.${parseInt(mappedHexIpv4[1], 16) & 0xff}.${parseInt(mappedHexIpv4[2], 16) >> 8}.${parseInt(mappedHexIpv4[2], 16) & 0xff}`
+    : '')
+  const ipv4 = (mappedIpv4 || host).match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/)
   if (!ipv4) return false
   const octets = ipv4.slice(1).map(Number)
   if (octets.some((part) => part > 255)) return true

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -13,13 +13,56 @@ function absolute(base: string, value: string): string {
   return new URL(value, base).toString()
 }
 
+function xpathToCss(value: string, field: string): string {
+  const expression = value.replace(/\/text\(\)\s*$/, '').trim()
+  if (!expression.startsWith('//')) throw new Error(`${field} 的 XPath 必须以 // 开头`)
+  const parts = expression.split(/(\/\/|\/)/).filter(Boolean)
+  const output: string[] = []
+  let combinator = ''
+
+  for (const part of parts) {
+    if (part === '//') {
+      combinator = ' '
+      continue
+    }
+    if (part === '/') {
+      combinator = ' > '
+      continue
+    }
+    const match = /^([a-z*][\w-]*)(?:\[(.+)\])?$/i.exec(part)
+    if (!match) throw new Error(`${field} 含不支持的 XPath 片段：${part}`)
+    const [, tag, predicate] = match
+    let css = tag
+    if (predicate) {
+      if (/^\d+$/.test(predicate)) css += `:nth-of-type(${predicate})`
+      else {
+        const equals = /^@([\w-]+)\s*=\s*(['"])(.*?)\2$/.exec(predicate)
+        const contains = /^contains\(\s*@([\w-]+)\s*,\s*(['"])(.*?)\2\s*\)$/.exec(predicate)
+        const exists = /^@([\w-]+)$/.exec(predicate)
+        if (equals) css += `[${equals[1]}="${escapeCssString(equals[3])}"]`
+        else if (contains) css += `[${contains[1]}*="${escapeCssString(contains[3])}"]`
+        else if (exists) css += `[${exists[1]}]`
+        else throw new Error(`${field} 含不支持的 XPath 谓词：${predicate}`)
+      }
+    }
+    output.push(`${output.length ? combinator || ' > ' : ''}${css}`)
+    combinator = ' > '
+  }
+  return output.join('')
+}
+
+function escapeCssString(value: string): string {
+  return value.replace(/["\\\n\r\f]/g, (character) => `\\${character}`)
+}
+
 function selector(rule: string, field: string): string {
   const value = String(rule || '').trim()
-  if (!value || value.startsWith('//')) throw new Error(`${field} 必须是 CSS 选择器；XPath 与 WebView 规则暂不支持`)
-  return value
+  if (!value) throw new Error(`${field} 不能为空`)
+  return value.startsWith('//') ? xpathToCss(value, field) : value
 }
 
 async function getHtml(url: string, cfg: PluginConfig, rule?: StreamRule): Promise<string> {
+  if (rule && !isAllowedForRule(url, rule)) throw new Error('流媒体地址不在当前规则允许域内')
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), Math.min(cfg.timeoutMs, 15000))
   try {
@@ -49,7 +92,7 @@ export function validateRule(raw: unknown): { rule: StreamRule; warning?: string
   for (const key of required) if (!String(rule[key] || '').trim()) throw new Error(`规则缺少必要字段：${key}`)
   if (!/^https?:\/\//i.test(rule.baseURL)) throw new Error('baseURL 必须是 http 或 https 地址')
   for (const key of ['searchList', 'searchName', 'searchResult', 'chapterRoads', 'chapterResult'] as const) selector(String(rule[key]), key)
-  return { rule, warning: rule.useWebview ? '该规则声明 useWebview；仅静态 CSS 解析可用，部分剧集可能无法播放。' : undefined }
+  return { rule, warning: rule.useWebview ? '该规则声明 useWebview；仅静态 XPath/CSS 解析可用，部分剧集可能无法播放。' : undefined }
 }
 
 export async function aggregateStreams(items: Array<{ title?: string; nameOrig?: string }>, cfg: PluginConfig): Promise<StreamSource[]> {
@@ -103,6 +146,9 @@ async function parseEpisodes(sourceUrl: string, rule: StreamRule, cfg: PluginCon
 
 export async function resolveStream(source: StreamSource, episode: StreamEpisode, rule: StreamRule, cfg: PluginConfig): Promise<StreamQuality[]> {
   if (!rule.enabled || !cfg.streamEnabled) throw new Error('流媒体功能或规则已关闭')
+  if (!isAllowedForRule(source.sourceUrl, rule) || !isAllowedForRule(episode.pageUrl, rule)) {
+    throw new Error('播放源或剧集地址不在当前规则允许域内')
+  }
   const html = await getHtml(episode.pageUrl, cfg, rule)
   const $ = cheerio.load(html)
   const urls = rule.playURLs
@@ -112,9 +158,20 @@ export async function resolveStream(source: StreamSource, episode: StreamEpisode
     const url = absolute(episode.pageUrl, value)
     const format = formatFrom(url)
     return { label: index === 0 ? '自动' : `线路 ${index + 1}`, url, format }
-  }).filter((quality): quality is StreamQuality => quality.format !== 'unknown')
+  }).filter((quality): quality is StreamQuality => quality.format !== 'unknown' && isAllowedForRule(quality.url, rule))
   if (!qualities.length) throw new Error('该集未解析出 MP4 或 HLS 播放地址')
   return qualities
+}
+
+export function isAllowedForRule(target: string, rule: StreamRule): boolean {
+  try {
+    const url = new URL(target)
+    const base = new URL(rule.baseURL)
+    return /^https?:$/.test(url.protocol) &&
+      (url.hostname === base.hostname || url.hostname.endsWith(`.${base.hostname}`))
+  } catch {
+    return false
+  }
 }
 
 export function isAllowedStreamUrl(target: string, cfg: PluginConfig): StreamRule | undefined {
@@ -123,9 +180,6 @@ export function isAllowedStreamUrl(target: string, cfg: PluginConfig): StreamRul
   if (!/^https?:$/.test(url.protocol) || !cfg.streamEnabled) return undefined
   return cfg.streamRules.find((rule) => {
     if (!rule.enabled) return false
-    try {
-      const base = new URL(rule.baseURL)
-      return url.hostname === base.hostname || url.hostname.endsWith(`.${base.hostname}`)
-    } catch { return false }
+    return isAllowedForRule(url.toString(), rule)
   })
 }

--- a/src/tests/parse.test.ts
+++ b/src/tests/parse.test.ts
@@ -84,6 +84,8 @@ test('enrichCardsWithBangumi fills score, tags and Bangumi id from search', asyn
     userAgent: 'anime-find test',
     maxResults: 12,
     sources: ['mikan'],
+    streamEnabled: false,
+    streamRules: [],
   }
   const cards: AnimeCard[] = [{ id: 'mikan:1', title: '摩绪', sources: ['mikan'], refs: { mikan: '1' } }]
   try {
@@ -125,6 +127,8 @@ test('enrichCardsWithBangumi loads a subject by existing bgmId', async () => {
     userAgent: 'anime-find test',
     maxResults: 12,
     sources: ['mikan'],
+    streamEnabled: false,
+    streamRules: [],
   }
   const cards: AnimeCard[] = [{ id: 'mikan:1', title: '摩绪', bgmId: '481410', sources: ['mikan'], refs: { mikan: '1' } }]
   try {
@@ -153,6 +157,8 @@ test('enrichCardsWithBangumi keeps the original card when Bangumi fails', async 
     userAgent: 'anime-find test',
     maxResults: 12,
     sources: ['mikan'],
+    streamEnabled: false,
+    streamRules: [],
   }
   const cards: AnimeCard[] = [{ id: 'mikan:1', title: '摩绪', sources: ['mikan'], refs: { mikan: '1' } }]
   try {
@@ -187,6 +193,8 @@ test('loadBangumiMeta isolates introduction and comment failures', async () => {
     userAgent: 'anime-find test',
     maxResults: 12,
     sources: ['mikan'],
+    streamEnabled: false,
+    streamRules: [],
   }
   try {
     globalThis.fetch = async (input) => {

--- a/src/tests/streaming.test.ts
+++ b/src/tests/streaming.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { isAllowedStreamUrl, validateRule } from '../streaming.js'
-import type { PluginConfig, StreamRule } from '../types.js'
+import { isAllowedForRule, isAllowedStreamUrl, resolveStream, validateRule } from '../streaming.js'
+import type { PluginConfig, StreamRule, StreamSource } from '../types.js'
 
 const rule: StreamRule = {
   id: 'demo',
@@ -28,12 +28,39 @@ const config: PluginConfig = {
   streamRules: [rule],
 }
 
-test('validateRule rejects XPath-only rules', () => {
-  assert.throws(() => validateRule({ ...rule, searchList: '//div' }), /CSS/)
+test('validateRule accepts the static XPath subset used by KazumiRules', () => {
+  const validated = validateRule({
+    ...rule,
+    searchList: '//div[2]/div',
+    searchName: '//div[2]/text()',
+    searchResult: '//a',
+    chapterRoads: '//div[contains(@class, "episode")]//div',
+    chapterResult: '//a',
+  })
+  assert.equal(validated.rule.searchList, '//div[2]/div')
+  assert.throws(() => validateRule({ ...rule, searchList: '//div[position()=1]' }), /不支持/)
 })
 
 test('media allowlist only accepts enabled rule domains', () => {
   assert.equal(isAllowedStreamUrl('https://cdn.media.example.test/a.m3u8', config)?.id, 'demo')
   assert.equal(isAllowedStreamUrl('https://untrusted.example/a.m3u8', config), undefined)
   assert.equal(isAllowedStreamUrl('file:///etc/passwd', config), undefined)
+})
+
+test('resolve rejects an episode outside its rule domain before fetching', async () => {
+  const source: StreamSource = {
+    id: 'source',
+    animeTitle: 'Demo',
+    ruleId: rule.id,
+    ruleName: rule.name,
+    lineName: 'line',
+    sourceUrl: 'https://media.example.test/detail',
+    episodes: [],
+    status: 'ready',
+  }
+  assert.equal(isAllowedForRule('http://127.0.0.1/private', rule), false)
+  await assert.rejects(
+    resolveStream(source, { id: 'episode', name: '1', pageUrl: 'http://127.0.0.1/private' }, rule, config),
+    /不在当前规则允许域内/,
+  )
 })

--- a/src/tests/streaming.test.ts
+++ b/src/tests/streaming.test.ts
@@ -4,6 +4,7 @@ import { readFileSync } from 'node:fs'
 import { createServer } from 'node:http'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { sanitizeStreamRules } from '../config-store.js'
 import { handleHlsAsset, handleMedia } from '../host.js'
 import { aggregateStreams, fetchAllowedStream, isAllowedForRule, isAllowedStreamUrl, resolveStream, runWithConcurrency, validateRule } from '../streaming.js'
 import type { PluginConfig, StreamRule, StreamSource } from '../types.js'
@@ -80,12 +81,26 @@ test('streaming player navigation follows the rendered episode order with disabl
   assert.match(clientSource, /"下一集"/)
 })
 
+test('client selects hls.js from resolved quality format, including signed HLS URLs', () => {
+  assert.match(clientSource, /const isHls = currentQuality\?\.format === "hls"/)
+  assert.match(clientSource, /if \(!video \|\| !currentUrl \|\| !isHls\) return/)
+  assert.match(clientSource, /src: isHls \? undefined : pluginUrl\(currentUrl\)/)
+  assert.doesNotMatch(clientSource, /\.m3u8\(\?:\\\?\|\$\)\/i\.test\(currentUrl\)/)
+})
+
 test('media allowlist only accepts enabled rule domains', () => {
   assert.equal(isAllowedStreamUrl('https://cdn.media.example.test/a.m3u8', config)?.id, 'demo')
   assert.equal(isAllowedStreamUrl('https://untrusted.example/a.m3u8', config), undefined)
   assert.equal(isAllowedStreamUrl('file:///etc/passwd', config), undefined)
   assert.equal(isAllowedForRule('http://127.0.0.1/private', rule), false)
   assert.equal(isAllowedForRule('http://169.254.169.254/latest/meta-data', { ...rule, baseURL: 'http://169.254.169.254' }), false)
+  assert.equal(isAllowedForRule('http://[::ffff:127.0.0.1]/private', { ...rule, baseURL: 'http://[::ffff:127.0.0.1]' }), false)
+  assert.equal(isAllowedForRule('http://[::ffff:169.254.169.254]/latest/meta-data', { ...rule, baseURL: 'http://[::ffff:169.254.169.254]' }), false)
+})
+
+test('rule persistence rejects private IPv4-mapped IPv6 origins', () => {
+  assert.deepEqual(sanitizeStreamRules([{ ...rule, baseURL: 'http://[::ffff:127.0.0.1]' }]), [])
+  assert.deepEqual(sanitizeStreamRules([{ ...rule, baseURL: 'http://[::ffff:169.254.169.254]' }]), [])
 })
 
 test('rule fetch refuses a redirect from an allowed domain to a private address', async () => {

--- a/src/tests/streaming.test.ts
+++ b/src/tests/streaming.test.ts
@@ -6,7 +6,7 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { sanitizeStreamRules } from '../config-store.js'
 import { handleHlsAsset, handleMedia } from '../host.js'
-import { aggregateStreams, fetchAllowedStream, isAllowedForRule, isAllowedStreamUrl, resolveStream, runWithConcurrency, validateRule } from '../streaming.js'
+import { aggregateStreams, extractScriptValue, fetchAllowedStream, isAllowedForRule, isAllowedStreamUrl, normalizeMediaHosts, resolveStream, runWithConcurrency, validateRule } from '../streaming.js'
 import type { PluginConfig, StreamRule, StreamSource } from '../types.js'
 
 const clientSource = readFileSync(join(dirname(fileURLToPath(import.meta.url)), '../../src/client.js'), 'utf8')
@@ -201,6 +201,138 @@ test('HLS player asset is served from the ToolView script path', async () => {
     assert.equal(Number(response.headers.get('content-length')), Buffer.byteLength(body))
   } finally {
     await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()))
+  }
+})
+
+test('script: playURL reads the media URL out of an inline MacCMS player object', () => {
+  const plain = '<script>var player_aaaa={"flag":"play","encrypt":0,"url":"https:\\/\\/cdn.example.test\\/a.mp4","url_next":"b"}</script>'
+  assert.equal(extractScriptValue(plain, 'player_aaaa.url'), 'https://cdn.example.test/a.mp4')
+
+  const encoded = '<script>var player_aaaa={"encrypt":1,"url":"https%3A%2F%2Fcdn.example.test%2Fb.m3u8"}</script>'
+  assert.equal(extractScriptValue(encoded, 'player_aaaa.url'), 'https://cdn.example.test/b.m3u8')
+
+  const base64 = `<script>var player_aaaa={"encrypt":2,"url":"${Buffer.from('https%3A%2F%2Fcdn.example.test%2Fc.mp4').toString('base64')}"}</script>`
+  assert.equal(extractScriptValue(base64, 'player_aaaa.url'), 'https://cdn.example.test/c.mp4')
+
+  // A brace inside a string must not terminate the object scan.
+  const braceInString = '<script>var player_aaaa={"title":"a}b","encrypt":0,"url":"https:\\/\\/cdn.example.test\\/d.mp4"}</script>'
+  assert.equal(extractScriptValue(braceInString, 'player_aaaa.url'), 'https://cdn.example.test/d.mp4')
+
+  assert.throws(() => extractScriptValue('<script>var other={}</script>', 'player_aaaa.url'), /未找到脚本变量/)
+  assert.throws(() => extractScriptValue('<script>var player_aaaa={"encrypt":0}</script>', 'player_aaaa.url'), /缺少字段/)
+  assert.throws(() => extractScriptValue('<script>var player_aaaa={}</script>', 'player_aaaa'), /script:变量名\.字段名/)
+})
+
+test('resolve reads a script-hosted media URL and honours the rule media allowlist', async () => {
+  const originalFetch = globalThis.fetch
+  const scriptRule: StreamRule = {
+    ...rule,
+    playURL: 'script:player_aaaa.url',
+    mediaHosts: ['cdn.other.test'],
+  }
+  const source: StreamSource = {
+    id: 'source',
+    animeTitle: 'Demo',
+    ruleId: scriptRule.id,
+    ruleName: scriptRule.name,
+    lineName: 'line',
+    sourceUrl: 'https://media.example.test/detail',
+    episodes: [],
+    status: 'ready',
+  }
+  const episode = { id: 'e1', name: '第 1 集', pageUrl: 'https://media.example.test/watch/1' }
+  try {
+    globalThis.fetch = async () => new Response(
+      '<script>var player_aaaa={"encrypt":0,"url":"https:\\/\\/cdn.other.test/a.mp4"}</script>',
+      { status: 200, headers: { 'content-type': 'text/html' } },
+    )
+    const qualities = await resolveStream(source, episode, scriptRule, { ...config, streamRules: [scriptRule] })
+    assert.deepEqual(qualities, [{ label: '自动', url: 'https://cdn.other.test/a.mp4', format: 'mp4' }])
+
+    // Same page, but the rule no longer declares that CDN.
+    await assert.rejects(
+      resolveStream(source, episode, { ...scriptRule, mediaHosts: [] }, { ...config, streamRules: [scriptRule] }),
+      /未解析出 MP4 或 HLS 播放地址/,
+    )
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test('declared media hosts widen the media allowlist without widening page fetches', () => {
+  const cdnRule: StreamRule = { ...rule, mediaHosts: ['cdn.other.test'] }
+  const cdnConfig: PluginConfig = { ...config, streamRules: [cdnRule] }
+  assert.equal(isAllowedForRule('https://cdn.other.test/a.mp4', cdnRule, 'media'), true)
+  assert.equal(isAllowedForRule('https://edge.cdn.other.test/a.mp4', cdnRule, 'media'), true)
+  assert.equal(isAllowedForRule('https://cdn.other.test/a.mp4', cdnRule, 'page'), false)
+  assert.equal(isAllowedForRule('https://unlisted.test/a.mp4', cdnRule, 'media'), false)
+  assert.equal(isAllowedStreamUrl('https://cdn.other.test/a.mp4', cdnConfig)?.id, 'demo')
+
+  // Declared hosts still cannot reach private or link-local addresses.
+  assert.equal(isAllowedForRule('http://127.0.0.1/a.mp4', { ...rule, mediaHosts: ['127.0.0.1'] }, 'media'), false)
+  assert.equal(isAllowedForRule('http://169.254.169.254/a.mp4', { ...rule, mediaHosts: ['169.254.169.254'] }, 'media'), false)
+  assert.deepEqual(normalizeMediaHosts(['127.0.0.1', 'localhost', 'no-dot', '', 'CDN.Other.Test']), ['cdn.other.test'])
+})
+
+test('rule persistence keeps media hosts and media headers, dropping private ones', () => {
+  const [stored] = sanitizeStreamRules([{
+    ...rule,
+    mediaHosts: ['CDN.Other.Test', '10.0.0.5', 'localhost'],
+    mediaHeaders: {
+      'x-token': 'abc',
+      'bad header': 'nope',
+      'CDN.Other.Test': { referer: '' },
+      '127.0.0.1': { referer: '' },
+    },
+  }])
+  assert.deepEqual(stored.mediaHosts, ['cdn.other.test'])
+  assert.deepEqual(stored.mediaHeaders, { 'x-token': 'abc', 'cdn.other.test': { referer: '' } })
+})
+
+test('media headers apply per host so CDNs with opposite Referer rules both work', async () => {
+  const originalFetch = globalThis.fetch
+  const seen: Array<string | null> = []
+  const cdnRule: StreamRule = {
+    ...rule,
+    mediaHosts: ['picky.test', 'needy.test'],
+    mediaHeaders: { 'picky.test': { referer: '' } },
+  }
+  try {
+    globalThis.fetch = async (_input, init) => {
+      seen.push(new Headers(init?.headers).get('referer'))
+      return new Response('', { status: 200 })
+    }
+    await fetchAllowedStream('https://media.example.test/page', cdnRule, config)
+    await fetchAllowedStream('https://picky.test/a.mp4', cdnRule, config, {}, 'media')
+    await fetchAllowedStream('https://edge.picky.test/a.mp4', cdnRule, config, {}, 'media')
+    await fetchAllowedStream('https://needy.test/a.mp4', cdnRule, config, {}, 'media')
+    assert.deepEqual(seen, ['https://media.example.test', null, null, 'https://media.example.test'])
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test('media headers are recomputed across redirects between CDNs', async () => {
+  const originalFetch = globalThis.fetch
+  const seen: Array<[string, string | null]> = []
+  const cdnRule: StreamRule = {
+    ...rule,
+    mediaHosts: ['needy.test', 'picky.test'],
+    mediaHeaders: { 'picky.test': { referer: '' } },
+  }
+  try {
+    globalThis.fetch = async (input, init) => {
+      const url = String(input)
+      seen.push([new URL(url).hostname, new Headers(init?.headers).get('referer')])
+      return url.includes('needy.test')
+        ? new Response('', { status: 302, headers: { location: 'https://picky.test/signed.mp4' } })
+        : new Response('', { status: 206 })
+    }
+    const res = await fetchAllowedStream('https://needy.test/a.mp4', cdnRule, config, {}, 'media')
+    assert.equal(res.status, 206)
+    assert.deepEqual(seen, [['needy.test', 'https://media.example.test'], ['picky.test', null]])
+  } finally {
+    globalThis.fetch = originalFetch
   }
 })
 

--- a/src/tests/streaming.test.ts
+++ b/src/tests/streaming.test.ts
@@ -4,7 +4,7 @@ import { readFileSync } from 'node:fs'
 import { createServer } from 'node:http'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { sanitizeStreamRules } from '../config-store.js'
+import { sanitizeStreamRules, DEFAULT_STREAM_RULES } from '../config-store.js'
 import { handleHlsAsset, handleMedia } from '../host.js'
 import { aggregateStreams, extractScriptValue, fetchAllowedStream, isAllowedForRule, isAllowedStreamUrl, normalizeMediaHosts, resolveStream, runWithConcurrency, validateRule } from '../streaming.js'
 import type { PluginConfig, StreamRule, StreamSource } from '../types.js'
@@ -50,9 +50,23 @@ test('validateRule accepts the static XPath subset used by KazumiRules', () => {
 })
 
 test('client settings copy advertises the static CSS or limited XPath subset', () => {
-  assert.match(clientSource, /首期支持静态 CSS 或受限 XPath 子集，不支持 WebView 拦截/)
+  assert.match(clientSource, /首期支持静态 CSS、受限 XPath 与 script: 取址，不支持 WebView 拦截/)
+  assert.match(clientSource, /在线播放（默认开启）/)
+  assert.match(clientSource, /DEFAULT_STREAM_RULES/)
+  assert.match(clientSource, /playURL: "script:player_aaaa\.url"/)
   assert.match(clientSource, /粘贴兼容的静态 CSS 或受限 XPath 子集规则/)
+  assert.doesNotMatch(clientSource, /在线播放（默认关闭）/)
   assert.doesNotMatch(clientSource, /首期仅支持静态 CSS 解析规则/)
+})
+
+test('bundled default stream rules validate and include script playURL', () => {
+  assert.ok(DEFAULT_STREAM_RULES.length >= 1)
+  for (const rule of DEFAULT_STREAM_RULES) {
+    const validated = validateRule(rule)
+    assert.equal(validated.rule.id, rule.id)
+    assert.match(String(rule.playURL || ''), /^script:/)
+    assert.ok(Array.isArray(rule.mediaHosts) && rule.mediaHosts.length > 0)
+  }
 })
 
 test('streaming ToolView provides stable browser E2E selectors and card state labels', () => {

--- a/src/tests/streaming.test.ts
+++ b/src/tests/streaming.test.ts
@@ -59,9 +59,21 @@ test('streaming ToolView provides stable browser E2E selectors and card state la
   assert.match(clientSource, /data-testid": "stream-tab"/)
   assert.match(clientSource, /data-testid": "stream-source-card"/)
   assert.match(clientSource, /data-testid": "stream-episode"/)
+  assert.match(clientSource, /data-testid": "stream-previous-episode"/)
+  assert.match(clientSource, /data-testid": "stream-next-episode"/)
   assert.match(clientSource, /"可播放"/)
   assert.match(clientSource, /"部分集受限"/)
   assert.match(clientSource, /"选集播放 ›"/)
+})
+
+test('streaming player navigation follows the rendered episode order with disabled boundaries', () => {
+  assert.match(clientSource, /const episodeIndex = episode \? ordered\.findIndex/)
+  assert.match(clientSource, /const previousEpisode = episodeIndex > 0/)
+  assert.match(clientSource, /const nextEpisode = episodeIndex >= 0 && episodeIndex < ordered\.length - 1/)
+  assert.match(clientSource, /disabled: !previousEpisode/)
+  assert.match(clientSource, /disabled: !nextEpisode/)
+  assert.match(clientSource, /"上一集"/)
+  assert.match(clientSource, /"下一集"/)
 })
 
 test('media allowlist only accepts enabled rule domains', () => {

--- a/src/tests/streaming.test.ts
+++ b/src/tests/streaming.test.ts
@@ -5,7 +5,7 @@ import { createServer } from 'node:http'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { handleHlsAsset, handleMedia } from '../host.js'
-import { isAllowedForRule, isAllowedStreamUrl, resolveStream, validateRule } from '../streaming.js'
+import { aggregateStreams, fetchAllowedStream, isAllowedForRule, isAllowedStreamUrl, resolveStream, runWithConcurrency, validateRule } from '../streaming.js'
 import type { PluginConfig, StreamRule, StreamSource } from '../types.js'
 
 const clientSource = readFileSync(join(dirname(fileURLToPath(import.meta.url)), '../../src/client.js'), 'utf8')
@@ -64,6 +64,10 @@ test('streaming ToolView provides stable browser E2E selectors and card state la
   assert.match(clientSource, /"可播放"/)
   assert.match(clientSource, /"部分集受限"/)
   assert.match(clientSource, /"选集播放 ›"/)
+  assert.match(clientSource, /未知格式/)
+  assert.match(clientSource, /打开插件设置/)
+  assert.match(clientSource, /toggleRule/)
+  assert.match(clientSource, /ruleWarnings/)
 })
 
 test('streaming player navigation follows the rendered episode order with disabled boundaries', () => {
@@ -80,6 +84,61 @@ test('media allowlist only accepts enabled rule domains', () => {
   assert.equal(isAllowedStreamUrl('https://cdn.media.example.test/a.m3u8', config)?.id, 'demo')
   assert.equal(isAllowedStreamUrl('https://untrusted.example/a.m3u8', config), undefined)
   assert.equal(isAllowedStreamUrl('file:///etc/passwd', config), undefined)
+  assert.equal(isAllowedForRule('http://127.0.0.1/private', rule), false)
+  assert.equal(isAllowedForRule('http://169.254.169.254/latest/meta-data', { ...rule, baseURL: 'http://169.254.169.254' }), false)
+})
+
+test('rule fetch refuses a redirect from an allowed domain to a private address', async () => {
+  const originalFetch = globalThis.fetch
+  try {
+    globalThis.fetch = async () => new Response('', {
+      status: 302,
+      headers: { location: 'http://127.0.0.1/private' },
+    })
+    await assert.rejects(
+      fetchAllowedStream('https://media.example.test/redirect', rule, config),
+      /不在当前规则允许域内/,
+    )
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test('stream aggregation limits concurrent source-site requests', async () => {
+  let active = 0
+  let peak = 0
+  const tasks = Array.from({ length: 10 }, (_, index) => async () => {
+    active++; peak = Math.max(peak, active)
+    await new Promise((resolve) => setTimeout(resolve, 5))
+    active--
+    return index
+  })
+  const results = await runWithConcurrency(tasks, 3)
+  assert.equal(peak, 3)
+  assert.deepEqual(results.map((item) => item.status === 'fulfilled' ? item.value : -1), [...Array(10).keys()])
+})
+
+test('fixture flow parses search results and episodes before resolving a media URL', async () => {
+  const originalFetch = globalThis.fetch
+  const fixtureRule: StreamRule = { ...rule, playURL: 'video' }
+  try {
+    globalThis.fetch = async (input) => {
+      const url = String(input)
+      const html = url.includes('/search')
+        ? '<div class="result"><span class="name">Fixture Anime</span><a href="/detail">detail</a></div>'
+        : url.includes('/detail')
+          ? '<div class="episode"><a href="/episode/1">第 1 集</a></div>'
+          : '<video src="/media/episode-1.m3u8"></video>'
+      return new Response(html, { status: 200, headers: { 'content-type': 'text/html' } })
+    }
+    const sources = await aggregateStreams([{ title: 'Fixture Anime' }], { ...config, streamRules: [fixtureRule] })
+    assert.equal(sources.length, 1)
+    assert.equal(sources[0].episodes.length, 1)
+    const qualities = await resolveStream(sources[0], sources[0].episodes[0], fixtureRule, config)
+    assert.deepEqual(qualities.map((item) => item.format), ['hls'])
+  } finally {
+    globalThis.fetch = originalFetch
+  }
 })
 
 test('media proxy recalculates Content-Length after rewriting an HLS playlist', async () => {

--- a/src/tests/streaming.test.ts
+++ b/src/tests/streaming.test.ts
@@ -54,6 +54,16 @@ test('client settings copy advertises the static CSS or limited XPath subset', (
   assert.doesNotMatch(clientSource, /首期仅支持静态 CSS 解析规则/)
 })
 
+test('streaming ToolView provides stable browser E2E selectors and card state labels', () => {
+  assert.match(clientSource, /data-testid": "resource-tab"/)
+  assert.match(clientSource, /data-testid": "stream-tab"/)
+  assert.match(clientSource, /data-testid": "stream-source-card"/)
+  assert.match(clientSource, /data-testid": "stream-episode"/)
+  assert.match(clientSource, /"可播放"/)
+  assert.match(clientSource, /"部分集受限"/)
+  assert.match(clientSource, /"选集播放 ›"/)
+})
+
 test('media allowlist only accepts enabled rule domains', () => {
   assert.equal(isAllowedStreamUrl('https://cdn.media.example.test/a.m3u8', config)?.id, 'demo')
   assert.equal(isAllowedStreamUrl('https://untrusted.example/a.m3u8', config), undefined)

--- a/src/tests/streaming.test.ts
+++ b/src/tests/streaming.test.ts
@@ -4,7 +4,7 @@ import { readFileSync } from 'node:fs'
 import { createServer } from 'node:http'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { handleMedia } from '../host.js'
+import { handleHlsAsset, handleMedia } from '../host.js'
 import { isAllowedForRule, isAllowedStreamUrl, resolveStream, validateRule } from '../streaming.js'
 import type { PluginConfig, StreamRule, StreamSource } from '../types.js'
 
@@ -87,6 +87,23 @@ test('media proxy recalculates Content-Length after rewriting an HLS playlist', 
     assert.ok(Buffer.byteLength(body) > Buffer.byteLength(playlist))
   } finally {
     globalThis.fetch = originalFetch
+    await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()))
+  }
+})
+
+test('HLS player asset is served from the ToolView script path', async () => {
+  const server = createServer((_req, res) => { void handleHlsAsset(res) })
+  try {
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+    const address = server.address()
+    assert.ok(address && typeof address !== 'string')
+    const response = await fetch(`http://127.0.0.1:${address.port}/plugins/anime-find/hls.min.js`)
+    const body = await response.text()
+    assert.equal(response.status, 200)
+    assert.match(response.headers.get('content-type') || '', /^text\/javascript/)
+    assert.match(body, /Hls/)
+    assert.equal(Number(response.headers.get('content-length')), Buffer.byteLength(body))
+  } finally {
     await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()))
   }
 })

--- a/src/tests/streaming.test.ts
+++ b/src/tests/streaming.test.ts
@@ -1,7 +1,12 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { isAllowedForRule, isAllowedStreamUrl, resolveStream, validateRule } from '../streaming.js'
 import type { PluginConfig, StreamRule, StreamSource } from '../types.js'
+
+const clientSource = readFileSync(join(dirname(fileURLToPath(import.meta.url)), '../../src/client.js'), 'utf8')
 
 const rule: StreamRule = {
   id: 'demo',
@@ -39,6 +44,12 @@ test('validateRule accepts the static XPath subset used by KazumiRules', () => {
   })
   assert.equal(validated.rule.searchList, '//div[2]/div')
   assert.throws(() => validateRule({ ...rule, searchList: '//div[position()=1]' }), /不支持/)
+})
+
+test('client settings copy advertises the static CSS or limited XPath subset', () => {
+  assert.match(clientSource, /首期支持静态 CSS 或受限 XPath 子集，不支持 WebView 拦截/)
+  assert.match(clientSource, /粘贴兼容的静态 CSS 或受限 XPath 子集规则/)
+  assert.doesNotMatch(clientSource, /首期仅支持静态 CSS 解析规则/)
 })
 
 test('media allowlist only accepts enabled rule domains', () => {

--- a/src/tests/streaming.test.ts
+++ b/src/tests/streaming.test.ts
@@ -1,8 +1,10 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
+import { createServer } from 'node:http'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { handleMedia } from '../host.js'
 import { isAllowedForRule, isAllowedStreamUrl, resolveStream, validateRule } from '../streaming.js'
 import type { PluginConfig, StreamRule, StreamSource } from '../types.js'
 
@@ -56,6 +58,37 @@ test('media allowlist only accepts enabled rule domains', () => {
   assert.equal(isAllowedStreamUrl('https://cdn.media.example.test/a.m3u8', config)?.id, 'demo')
   assert.equal(isAllowedStreamUrl('https://untrusted.example/a.m3u8', config), undefined)
   assert.equal(isAllowedStreamUrl('file:///etc/passwd', config), undefined)
+})
+
+test('media proxy recalculates Content-Length after rewriting an HLS playlist', async () => {
+  const playlist = '#EXTM3U\n#EXT-X-KEY:METHOD=AES-128,URI="keys/secret.key"\nsegment.ts\n'
+  const originalFetch = globalThis.fetch
+  const server = createServer((req, res) => { void handleMedia(req, res, config) })
+  try {
+    globalThis.fetch = async (input, init) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.startsWith('http://127.0.0.1:')) return originalFetch(input, init)
+      return new Response(playlist, {
+        headers: {
+          'content-type': 'application/vnd.apple.mpegurl',
+          'content-length': String(Buffer.byteLength(playlist)),
+        },
+      })
+    }
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+    const address = server.address()
+    assert.ok(address && typeof address !== 'string')
+    const target = 'https://media.example.test/path/master.m3u8'
+    const response = await originalFetch(`http://127.0.0.1:${address.port}/anime-find/media?url=${encodeURIComponent(target)}`)
+    const body = await response.text()
+    assert.match(body, /keys%2Fsecret\.key/)
+    assert.match(body, /segment\.ts/)
+    assert.equal(Number(response.headers.get('content-length')), Buffer.byteLength(body))
+    assert.ok(Buffer.byteLength(body) > Buffer.byteLength(playlist))
+  } finally {
+    globalThis.fetch = originalFetch
+    await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()))
+  }
 })
 
 test('resolve rejects an episode outside its rule domain before fetching', async () => {

--- a/src/tests/streaming.test.ts
+++ b/src/tests/streaming.test.ts
@@ -1,0 +1,39 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { isAllowedStreamUrl, validateRule } from '../streaming.js'
+import type { PluginConfig, StreamRule } from '../types.js'
+
+const rule: StreamRule = {
+  id: 'demo',
+  name: 'Demo',
+  enabled: true,
+  baseURL: 'https://media.example.test',
+  searchURL: '/search?q={{keyword}}',
+  searchList: '.result',
+  searchName: '.name',
+  searchResult: 'a',
+  chapterRoads: '.episode',
+  chapterResult: 'a',
+}
+
+const config: PluginConfig = {
+  mikanHost: 'https://mikanani.me',
+  anibtHost: 'https://anibt.net',
+  gardenHost: 'https://api.animes.garden',
+  timeoutMs: 20000,
+  userAgent: 'test',
+  maxResults: 12,
+  sources: ['mikan'],
+  streamEnabled: true,
+  streamRules: [rule],
+}
+
+test('validateRule rejects XPath-only rules', () => {
+  assert.throws(() => validateRule({ ...rule, searchList: '//div' }), /CSS/)
+})
+
+test('media allowlist only accepts enabled rule domains', () => {
+  assert.equal(isAllowedStreamUrl('https://cdn.media.example.test/a.m3u8', config)?.id, 'demo')
+  assert.equal(isAllowedStreamUrl('https://untrusted.example/a.m3u8', config), undefined)
+  assert.equal(isAllowedStreamUrl('file:///etc/passwd', config), undefined)
+})

--- a/src/types.ts
+++ b/src/types.ts
@@ -123,9 +123,22 @@ export interface StreamRule {
   chapterRoads: string
   chapterResult: string
   chapterName?: string
+  /**
+   * Either a CSS/XPath selector whose src/href holds the media URL, or
+   * `script:<variable>.<field>` to read it out of an inline script object such
+   * as the `player_aaaa` payload common to MacCMS sites.
+   */
   playURL?: string
   playURLs?: string
+  /** Extra hosts the media URL may point at, for sites serving media off a CDN. */
+  mediaHosts?: string[]
   headers?: Record<string, string>
+  /**
+   * Applied on media requests only; an empty value removes the header. A key
+   * containing a dot is a host, and its nested map applies to that host and its
+   * subdomains only.
+   */
+  mediaHeaders?: Record<string, string | Record<string, string>>
   useWebview?: boolean
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -103,4 +103,52 @@ export interface PluginConfig {
   userAgent: string
   maxResults: number
   sources: SourceId[]
+  streamEnabled: boolean
+  streamRules: StreamRule[]
+}
+
+/**
+ * A deliberately small, static-compatible subset of Kazumi rules. The plugin
+ * does not execute page JavaScript or WebView interceptors.
+ */
+export interface StreamRule {
+  id: string
+  name: string
+  enabled: boolean
+  baseURL: string
+  searchURL: string
+  searchList: string
+  searchName: string
+  searchResult: string
+  chapterRoads: string
+  chapterResult: string
+  chapterName?: string
+  playURL?: string
+  playURLs?: string
+  headers?: Record<string, string>
+  useWebview?: boolean
+}
+
+export interface StreamEpisode {
+  id: string
+  name: string
+  pageUrl: string
+}
+
+export interface StreamSource {
+  id: string
+  animeTitle: string
+  ruleId: string
+  ruleName: string
+  lineName: string
+  sourceUrl: string
+  episodes: StreamEpisode[]
+  format?: 'hls' | 'mp4' | 'unknown'
+  status: 'ready' | 'limited'
+}
+
+export interface StreamQuality {
+  label: string
+  url: string
+  format: 'hls' | 'mp4'
 }


### PR DESCRIPTION
- **Add rule-based streaming playback**
- **Fix streaming resolve validation and XPath rules**
- **Fix streaming settings copy and ToolView XPath messaging**
- **Document MiniMax Harness verification**
- **Fix HLS proxy response length**
- **Fix HLS player asset delivery**
- **Refine streaming source cards for browser validation**
- **Fix streaming episode navigation controls**
- **Harden streaming redirects and rule controls**
- **Fix streaming playback safety edge cases**
- **Enable static MacCMS stream resolve with declared CDN allowlists**
- **Ship a default streaming rule so installs are not empty**
