### PR TITLE
Bump version to 0.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "anime-find",
-  "version": "0.1.3",
-  "description": "DeepSeek Harness 插件：对话内多源搜番，卡片详情与磁力复制",
+  "version": "0.1.4",
+  "description": "DeepSeek Harness 插件：对话内多源搜番，卡片详情、磁力复制与规则流媒体在线播放",
   "homepage": "https://github.com/cocofhu/anime-find#readme",
   "bugs": {
     "url": "https://github.com/cocofhu/anime-find/issues"


### PR DESCRIPTION
## Summary
- 将 `package.json` 版本升至 `0.1.4`，用于发布含流媒体在线播放能力的小版本 Release。

## Test plan
- [ ] CI 通过
- [ ] 合并后打 `v0.1.4` tag 并创建 GitHub Release


Made with [Cursor](https://cursor.com)