### PR TITLE
Fix settings plugin card for current Harness keyed slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ DSH_HOME="$DSH_HOME" npx @deepseek-ai/dsh plugin --profile web add /absolute/pat
 ## 故障排查
 
 - **页面停在 Loading plugins**：确认 `pnpm build` 成功，重启 `dsh web` 后强制刷新
+- **loader 报 `requires options.key`**：当前 Harness 把 `settings.plugin.item` 当作 keyed slot，客户端必须用 `key` 而不是 `id` 注册；Host 还需 `settings.register('anime-find', …)` 才能分发配置卡
 - **搜番卡片未出现**：开启新对话，并确认 `anime_find_search` 已加载
 - **本季结果较少**：提高结果上限，或在设置中启用 AniBT / AnimeGarden
 - **来源请求失败**：检查网络与对应站点地址；单个来源失败不会阻止其他来源返回结果

--- a/src/client.js
+++ b/src/client.js
@@ -1261,7 +1261,7 @@ window.__ModuleLoader__.load({
         DetailToolView,
       ));
       slots.inject("settings.plugin.item", () => slots.register(
-        { name: "settings.plugin.item", id: "anime-find", order: 30 },
+        { name: "settings.plugin.item", key: "anime-find", order: 30 },
         ConfigCard,
       ));
     }

--- a/src/host.ts
+++ b/src/host.ts
@@ -102,6 +102,15 @@ export function apply(ctx: Context, config: Config): void {
     // so the ToolView can load the package asset at /plugins/anime-find/hls.min.js.
     server.register({ kind: 'exact', path: '/plugins/anime-find/hls.min.js', handler: (_req, res) => handleHlsAsset(res) })
   })
+
+  // 插件配置页按 Host settings 命名空间分发 settings.plugin.item。
+  // 不登记 anime-find 的话，客户端卡片永远不会被 dispatch。
+  ctx.inject(['settings'], (c) => {
+    const settings = (c as unknown as {
+      settings: { register: (ns: string, schema: typeof Config, options?: { base?: Config }) => void }
+    }).settings
+    settings.register('anime-find', Config, { base: config })
+  })
 }
 
 function withDefaults(config: Config): PluginConfig {


### PR DESCRIPTION
## 改动说明

当前 Harness 把 `settings.plugin.item` 当作 keyed slot。anime-find 仍用 list-slot 的 `id` 注册，loader 会报 `requires options.key`，插件配置卡也无法分发。

- 客户端改为 `{ key: "anime-find" }`
- Host 通过 `settings.register('anime-find', Config, { base: config })` 登记命名空间
- README 故障排查补上对应说明

## 改动类型

- [x] Bug 修复
- [ ] 新功能或来源
- [ ] UI / 交互调整
- [ ] 重构
- [ ] 测试或文档

## 验证

- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] 已在 Harness Web 中手动验证（如适用）
- [ ] UI 改动已附截图（如适用）

## 安全与隐私

- [x] 未包含密钥、Cookie、个人数据、私有网络信息或本地配置
- [x] 新增网络请求设置了超时，并能处理来源失败

## 关联 Issue

N/A


Made with [Cursor](https://cursor.com)