### PR TITLE
Bump version to 0.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anime-find",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "DeepSeek Harness 插件：对话内多源搜番，卡片详情、磁力复制与规则流媒体在线播放",
   "homepage": "https://github.com/cocofhu/anime-find#readme",
   "bugs": {


### PR DESCRIPTION
## 改动说明

将 `package.json` 版本升至 `0.1.5`，用于发布含当前 Harness keyed-slot 修复与流媒体选集过滤的小版本 Release。

`v0.1.4` 已存在，本次包含其后的：

- 客户端 `settings.plugin.item` 改用 `key`，Host 登记 `anime-find` 命名空间，避免 loader 报 `requires options.key`
- 流媒体按可播选集行过滤剧集
- README 截图与 banner

## 改动类型

- [x] 测试或文档

## 验证

- [x] `pnpm typecheck`
- [x] `pnpm test`

## 安全与隐私

- [x] 未包含密钥、Cookie、个人数据、私有网络信息或本地配置

## Test plan

- [ ] CI 通过
- [ ] 合并后打 `v0.1.5` tag 并创建 GitHub Release


Made with [Cursor](https://cursor.com)