### PR TITLE
Bump version to 0.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anime-find",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "DeepSeek Harness 插件：对话内多源搜番，卡片详情、磁力复制与规则流媒体在线播放",
   "homepage": "https://github.com/cocofhu/anime-find#readme",
   "bugs": {


### PR DESCRIPTION
## Summary
- 将 `package.json` 版本升至 `0.1.6`，用于发布含一键更新并重启 dsh web 的小版本 Release。

`v0.1.5` 已存在，本次包含其后的：
- 设置页「更新」经确认后自动执行官方 update 命令
- 拉起继任 dsh web 并跳转到新地址
- 应用内确认弹窗与进度提示（不再用原生 alert/confirm）

## Test plan
- [ ] CI 通过
- [ ] 合并后打 `v0.1.6` tag 并创建 GitHub Release


Made with [Cursor](https://cursor.com)