### PR TITLE
Add npm Trusted Publishing on version tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,43 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    name: npm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Require npm 11.5.1+
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: pnpm typecheck
+
+      - name: Run tests
+        run: pnpm test
+
+      - name: Publish
+        run: npm publish --access public

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,3 +54,20 @@ pnpm test
 ```
 
 提交即表示你同意以本仓库的 [MIT License](LICENSE) 授权你的贡献。
+
+## 发布
+
+正式版走 GitHub Release tag，并由 `.github/workflows/publish.yml` 用 npm Trusted Publishing 发到 registry。不要把 `NPM_TOKEN` 写进 workflow。
+
+1. 升 `package.json` 的 `version`，合并进 `main`。
+2. 打 annotated tag 并推送，例如 `git tag -a v0.1.6 -m "v0.1.6" && git push origin v0.1.6`。
+3. 同时创建 GitHub Release；Actions 里的 Publish 会 `npm publish`。
+
+Trusted Publisher 在 https://www.npmjs.com/package/anime-find/access 绑定一次即可：
+
+- Organization or user：`cocofhu`
+- Repository：`anime-find`
+- Workflow filename：`publish.yml`
+- Environment name：留空
+- Allowed actions：`npm publish`
+

--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
     "bangumi"
   ],
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "packageManager": "pnpm@11.17.0",
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
## 改动说明

为 `v*` tag 增加 `.github/workflows/publish.yml`，用 GitHub OIDC 做 npm Trusted Publishing，发布步骤不使用 `NPM_TOKEN`。

合并后还需在 npm 包设置里绑定一次 Trusted Publisher（文件名必须是 `publish.yml`）。

## 改动类型

- [x] 测试或文档

## 验证

- [ ] CI 通过

## 安全与隐私

- [x] 未包含密钥、Cookie、个人数据、私有网络信息或本地配置


Made with [Cursor](https://cursor.com)