### PR TITLE
Bump version to 0.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anime-find",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "DeepSeek Harness 插件：对话内多源搜番，卡片详情、磁力复制与规则流媒体在线播放",
   "homepage": "https://github.com/cocofhu/anime-find#readme",
   "bugs": {


### PR DESCRIPTION
## 改动说明

将 `package.json` 升至 `0.1.7`，用来验证 Trusted Publishing：打 `v0.1.7` 后由 `publish.yml` 自动 `npm publish`。

`v0.1.6` 的 tag 早于 `publish.yml`，当时没有触发发布。

## 改动类型

- [x] 测试或文档

## 验证

- [ ] CI 通过
- [ ] 合并后打 `v0.1.7`，确认 Actions Publish 成功

## 安全与隐私

- [x] 未包含密钥、Cookie、个人数据、私有网络信息或本地配置


Made with [Cursor](https://cursor.com)