### PR TITLE
Document npm as the supported install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![anime-find](docs/banner.jpg)
 
 [![CI](https://github.com/cocofhu/anime-find/actions/workflows/ci.yml/badge.svg)](https://github.com/cocofhu/anime-find/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/anime-find.svg)](https://www.npmjs.com/package/anime-find)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 DeepSeek Harness 搜番插件。在对话中搜索番剧，以可点击卡片展示结果，并在详情面板中查看字幕组、磁力链接和种子文件。
@@ -26,19 +27,19 @@ DeepSeek Harness 搜番插件。在对话中搜索番剧，以可点击卡片展
 
 ## 安装
 
-从 GitHub 安装：
+从 [npm](https://www.npmjs.com/package/anime-find) 安装：
 
 ```sh
-dsh plugin --profile web add github:cocofhu/anime-find
+dsh plugin --profile web add anime-find
 ```
 
-本地开发安装：
+本地开发：
 
 ```sh
 dsh plugin --profile web add /absolute/path/to/anime-find
 ```
 
-安装后重启 `dsh web`，并强制刷新浏览器页面。
+安装后重启 `dsh web`，并强制刷新浏览器页面。不要用 `github:cocofhu/anime-find` 安装：git 源会跑 `prepare`，pnpm 会要求手写 `allowBuilds`。
 
 ## 使用
 
@@ -186,6 +187,7 @@ DSH_HOME="$DSH_HOME" npx @deepseek-ai/dsh plugin --profile web add /absolute/pat
 ## 故障排查
 
 - **页面停在 Loading plugins**：确认 `pnpm build` 成功，重启 `dsh web` 后强制刷新
+- **`ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED`**：改用 npm 安装 `dsh plugin --profile web add anime-find`，不要走 git 源
 - **loader 报 `requires options.key`**：当前 Harness 把 `settings.plugin.item` 当作 keyed slot，客户端必须用 `key` 而不是 `id` 注册；Host 还需 `settings.register('anime-find', …)` 才能分发配置卡
 - **搜番卡片未出现**：开启新对话，并确认 `anime_find_search` 已加载
 - **本季结果较少**：提高结果上限，或在设置中启用 AniBT / AnimeGarden

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anime-find",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "DeepSeek Harness 插件：对话内多源搜番，卡片详情、磁力复制与规则流媒体在线播放",
   "homepage": "https://github.com/cocofhu/anime-find#readme",
   "bugs": {

--- a/src/apply-update.ts
+++ b/src/apply-update.ts
@@ -1,6 +1,6 @@
 import { spawn as nodeSpawn } from 'node:child_process'
 import type { ChildProcess } from 'node:child_process'
-import { DEFAULT_PROFILE, type VersionMetadata } from './update-check.js'
+import { canAutoUpdate, DEFAULT_PROFILE, type VersionMetadata } from './update-check.js'
 
 const UPDATE_TIMEOUT_MS = 5 * 60_000
 const WEB_START_TIMEOUT_MS = 30_000
@@ -45,7 +45,7 @@ export async function applyPluginUpdate(
   profile = DEFAULT_PROFILE,
   dependencies: ApplyUpdateDependencies = {},
 ): Promise<ApplyUpdateResult> {
-  if (metadata.installSource !== 'github') {
+  if (!canAutoUpdate(metadata.installSource)) {
     return { ok: false, error: '当前为本地或未知安装来源，不能自动执行官方更新。' }
   }
   if (updating) return { ok: false, error: '已有更新正在进行，请稍候。' }

--- a/src/client.js
+++ b/src/client.js
@@ -1059,6 +1059,7 @@ window.__ModuleLoader__.load({
 
     function installSourceLabel(metadata) {
       const source = metadata?.installSource;
+      if (source === "npm") return `安装来源 · ${metadata.installReference || "npm:anime-find"}`;
       if (source === "github") return `安装来源 · ${metadata.installReference || "github:cocofhu/anime-find"}`;
       if (source === "local") return `安装来源 · ${metadata.installReference || "本地 link/file"}`;
       return "安装来源 · 未识别";

--- a/src/tests/apply-update.test.ts
+++ b/src/tests/apply-update.test.ts
@@ -44,6 +44,26 @@ test('refuses local and unknown installations before spawning', async () => {
   assert.equal(calls, 0)
 })
 
+test('allows npm installations to run the official update', async () => {
+  const children = [fakeChild(), fakeChild()]
+  let calls = 0
+  const spawn = (() => {
+    calls += 1
+    const child = children.shift()
+    if (!child) throw new Error('unexpected spawn')
+    if (calls === 1) queueMicrotask(() => child.emit('close', 0))
+    else queueMicrotask(() => child.stdout.end('dsh web: http://127.0.0.1:43124\n'))
+    return child
+  }) as never
+  const result = await applyPluginUpdate({ ...githubMetadata, installSource: 'npm', installReference: '^0.1.7' }, 'web', {
+    spawn,
+    cliPath: '/tmp/dsh.js',
+    scheduleExit: () => {},
+  })
+  assert.equal(result.ok, true)
+  assert.equal(result.newUrl, 'http://127.0.0.1:43124')
+})
+
 test('updates then starts a successor and returns its URL', async () => {
   const calls: Array<{ command: string; args: string[] }> = []
   const children = [fakeChild(), fakeChild()]

--- a/src/tests/update-check.test.ts
+++ b/src/tests/update-check.test.ts
@@ -10,6 +10,12 @@ const githubMetadata = {
   updateCommand: 'dsh plugin --profile web update anime-find',
 }
 
+const npmMetadata = {
+  ...githubMetadata,
+  installSource: 'npm' as const,
+  installReference: '^0.1.7',
+}
+
 const localMetadata = {
   ...githubMetadata,
   installSource: 'local' as const,
@@ -26,11 +32,20 @@ test('normalizes and compares release versions', () => {
   assert.equal(compareVersions('1.2.0', '1.2.0'), 0)
 })
 
-test('classifies GitHub and local install references', () => {
+test('classifies GitHub, npm and local install references', () => {
   assert.equal(classifyInstallSource('github:cocofhu/anime-find'), 'github')
+  assert.equal(classifyInstallSource('^0.1.7'), 'npm')
+  assert.equal(classifyInstallSource('0.1.7'), 'npm')
+  assert.equal(classifyInstallSource('https://registry.npmjs.org/anime-find/-/anime-find-0.1.7.tgz'), 'npm')
   assert.equal(classifyInstallSource('link:/workspace/anime-find'), 'local')
   assert.equal(classifyInstallSource('file:../anime-find'), 'local')
   assert.equal(classifyInstallSource(undefined), 'unknown')
+})
+
+test('reports an available update for an npm install', async () => {
+  const result = await checkForUpdate(npmMetadata, options, async () => ({ tag_name: 'v0.2.0' }))
+  assert.equal(result.status, 'updateAvailable')
+  assert.equal(result.latestVersion, '0.2.0')
 })
 
 test('reports an available update for a GitHub install', async () => {

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -9,7 +9,7 @@ const require = createRequire(import.meta.url)
 const REPOSITORY = 'cocofhu/anime-find'
 export const DEFAULT_PROFILE = process.env.DSH_PROFILE || 'web'
 
-export type InstallSource = 'github' | 'local' | 'unknown'
+export type InstallSource = 'github' | 'npm' | 'local' | 'unknown'
 export type UpdateStatus = 'upToDate' | 'updateAvailable' | 'noRelease' | 'failed' | 'localInstallRestricted'
 
 export interface VersionMetadata {
@@ -59,7 +59,7 @@ export async function checkForUpdate(
     if (compareVersions(latestVersion, metadata.currentVersion) <= 0) {
       return result(metadata, 'upToDate', `已是最新版本（当前 ${metadata.currentVersion}）。`, latestVersion)
     }
-    if (metadata.installSource !== 'github') {
+    if (!canAutoUpdate(metadata.installSource)) {
       return result(metadata, 'localInstallRestricted', '发现新正式版，但当前为本地或未知安装来源，请自行同步后重启。', latestVersion)
     }
     return result(metadata, 'updateAvailable', '发现新正式版，可按官方命令更新。', latestVersion)
@@ -89,10 +89,16 @@ export function compareVersions(left: string, right: string): number {
   return a.pre.localeCompare(b.pre, undefined, { numeric: true })
 }
 
+export function canAutoUpdate(source: InstallSource): boolean {
+  return source === 'github' || source === 'npm'
+}
+
 export function classifyInstallSource(reference?: string): InstallSource {
   if (!reference) return 'unknown'
   if (/^(github:|git\+https?:\/\/github\.com\/)/i.test(reference)) return 'github'
   if (/^(link:|file:|\.{1,2}\/|\/)/i.test(reference)) return 'local'
+  if (/^(npm:|https?:\/\/registry\.npmjs\.org\/)/i.test(reference)) return 'npm'
+  if (/^[~^>=<]*\d+\.\d+\.\d+/.test(reference.trim())) return 'npm'
   return 'unknown'
 }
 


### PR DESCRIPTION
## 改动说明

安装方式改为 npm：`dsh plugin --profile web add anime-find`。GitHub / npm README 共用这一份。

同时识别 npm 安装来源，设置页「更新」不再把 registry 版本当成未知来源。版本升至 `0.1.8`，合并后打 tag 即可更新 npm 页面上的 README。

## 改动类型

- [x] Bug 修复
- [x] 测试或文档

## 验证

- [x] `pnpm test`

## 安全与隐私

- [x] 未包含密钥、Cookie、个人数据、私有网络信息或本地配置


Made with [Cursor](https://cursor.com)