### PR TITLE
Publish as @cocofhu/anime-find

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ pnpm test
 2. 打 annotated tag 并推送，例如 `git tag -a v0.1.6 -m "v0.1.6" && git push origin v0.1.6`。
 3. 同时创建 GitHub Release；Actions 里的 Publish 会 `npm publish`。
 
-Trusted Publisher 在 https://www.npmjs.com/package/anime-find/access 绑定一次即可：
+Trusted Publisher 在 https://www.npmjs.com/package/@cocofhu/anime-find/access 绑定一次即可：
 
 - Organization or user：`cocofhu`
 - Repository：`anime-find`

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![anime-find](docs/banner.jpg)
 
 [![CI](https://github.com/cocofhu/anime-find/actions/workflows/ci.yml/badge.svg)](https://github.com/cocofhu/anime-find/actions/workflows/ci.yml)
-[![npm](https://img.shields.io/npm/v/anime-find.svg)](https://www.npmjs.com/package/anime-find)
+[![npm](https://img.shields.io/npm/v/@cocofhu/anime-find.svg)](https://www.npmjs.com/package/@cocofhu/anime-find)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 DeepSeek Harness 搜番插件。在对话中搜索番剧，以可点击卡片展示结果，并在详情面板中查看字幕组、磁力链接和种子文件。
@@ -27,10 +27,10 @@ DeepSeek Harness 搜番插件。在对话中搜索番剧，以可点击卡片展
 
 ## 安装
 
-从 [npm](https://www.npmjs.com/package/anime-find) 安装：
+从 [npm](https://www.npmjs.com/package/@cocofhu/anime-find) 安装：
 
 ```sh
-dsh plugin --profile web add anime-find
+dsh plugin --profile web add @cocofhu/anime-find
 ```
 
 本地开发：
@@ -39,7 +39,7 @@ dsh plugin --profile web add anime-find
 dsh plugin --profile web add /absolute/path/to/anime-find
 ```
 
-安装后重启 `dsh web`，并强制刷新浏览器页面。不要用 `github:cocofhu/anime-find` 安装：git 源会跑 `prepare`，pnpm 会要求手写 `allowBuilds`。
+安装后重启 `dsh web`，并强制刷新浏览器页面。不要用 `github:cocofhu/anime-find` 或无前缀的 `anime-find` 安装：git 源会跑 `prepare`；旧包名已迁到 `@cocofhu/anime-find`。
 
 ## 使用
 
@@ -136,7 +136,7 @@ Release。
 地址：
 
 ```sh
-dsh plugin --profile web update anime-find
+dsh plugin --profile web update @cocofhu/anime-find
 ```
 
 当前以 `link:` 或 `file:` 本地方式安装时，页面仍会显示版本对比，但禁止自动更新，
@@ -187,7 +187,7 @@ DSH_HOME="$DSH_HOME" npx @deepseek-ai/dsh plugin --profile web add /absolute/pat
 ## 故障排查
 
 - **页面停在 Loading plugins**：确认 `pnpm build` 成功，重启 `dsh web` 后强制刷新
-- **`ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED`**：改用 npm 安装 `dsh plugin --profile web add anime-find`，不要走 git 源
+- **`ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED`**：改用 npm 安装 `dsh plugin --profile web add @cocofhu/anime-find`，不要走 git 源或旧包名 `anime-find`
 - **loader 报 `requires options.key`**：当前 Harness 把 `settings.plugin.item` 当作 keyed slot，客户端必须用 `key` 而不是 `id` 注册；Host 还需 `settings.register('anime-find', …)` 才能分发配置卡
 - **搜番卡片未出现**：开启新对话，并确认 `anime_find_search` 已加载
 - **本季结果较少**：提高结果上限，或在设置中启用 AniBT / AnimeGarden

--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -1,6 +1,6 @@
 - insert:
     - id: anime-find
-      name: anime-find
+      name: '@cocofhu/anime-find'
       config:
         sources:
           - mikan

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "anime-find",
-  "version": "0.1.8",
+  "name": "@cocofhu/anime-find",
+  "version": "0.1.9",
   "description": "DeepSeek Harness 插件：对话内多源搜番，卡片详情、磁力复制与规则流媒体在线播放",
   "homepage": "https://github.com/cocofhu/anime-find#readme",
   "bugs": {

--- a/src/apply-update.ts
+++ b/src/apply-update.ts
@@ -1,6 +1,6 @@
 import { spawn as nodeSpawn } from 'node:child_process'
 import type { ChildProcess } from 'node:child_process'
-import { canAutoUpdate, DEFAULT_PROFILE, type VersionMetadata } from './update-check.js'
+import { canAutoUpdate, DEFAULT_PROFILE, NPM_PACKAGE, type VersionMetadata } from './update-check.js'
 
 const UPDATE_TIMEOUT_MS = 5 * 60_000
 const WEB_START_TIMEOUT_MS = 30_000
@@ -29,7 +29,7 @@ interface CommandResult {
 let updating = false
 
 export function buildUpdateArgv(profile = DEFAULT_PROFILE): string[] {
-  return ['plugin', '--profile', profile, 'update', 'anime-find']
+  return ['plugin', '--profile', profile, 'update', NPM_PACKAGE]
 }
 
 export function buildSuccessorWebArgv(profile = DEFAULT_PROFILE): string[] {

--- a/src/client.js
+++ b/src/client.js
@@ -1,5 +1,5 @@
 window.__ModuleLoader__.load({
-  id: "anime-find",
+  id: "@cocofhu/anime-find",
   factory: (require) => {
     const React = require("react");
     const h = React.createElement;
@@ -312,7 +312,7 @@ window.__ModuleLoader__.load({
           h("h3", { id: "af-update-confirm-title" }, "确认执行更新？"),
           h("p", null,
             "将执行 ",
-            h("code", null, command || "dsh plugin --profile web update anime-find"),
+            h("code", null, command || "dsh plugin --profile web update @cocofhu/anime-find"),
             "，成功后自动重启 dsh web 并跳转到新地址。更新期间当前页面会断开。",
           ),
           h("div", { className: "af-modal-actions" },

--- a/src/tests/apply-update.test.ts
+++ b/src/tests/apply-update.test.ts
@@ -8,7 +8,7 @@ const githubMetadata = {
   currentVersion: '0.1.0',
   installSource: 'github' as const,
   installReference: 'github:cocofhu/anime-find',
-  updateCommand: 'dsh plugin --profile web update anime-find',
+  updateCommand: 'dsh plugin --profile web update @cocofhu/anime-find',
 }
 
 function fakeChild() {
@@ -26,7 +26,7 @@ function fakeChild() {
 }
 
 test('uses fixed argv and parses successor web URL', () => {
-  assert.deepEqual(buildUpdateArgv('team'), ['plugin', '--profile', 'team', 'update', 'anime-find'])
+  assert.deepEqual(buildUpdateArgv('team'), ['plugin', '--profile', 'team', 'update', '@cocofhu/anime-find'])
   assert.deepEqual(buildSuccessorWebArgv('team'), ['--profile', 'team', '--port', '0'])
   assert.equal(parseSuccessorWebUrl('ready\ndsh web: http://127.0.0.1:48123/path\n'), 'http://127.0.0.1:48123/path')
 })
@@ -82,7 +82,7 @@ test('updates then starts a successor and returns its URL', async () => {
     scheduleExit: () => { exited = true },
   })
   assert.deepEqual(calls.map((call) => call.args), [
-    ['/tmp/dsh.js', 'plugin', '--profile', 'web', 'update', 'anime-find'],
+    ['/tmp/dsh.js', 'plugin', '--profile', 'web', 'update', '@cocofhu/anime-find'],
     ['/tmp/dsh.js', '--profile', 'web', '--port', '0'],
   ])
   assert.equal(result.ok, true)

--- a/src/tests/client-update.test.ts
+++ b/src/tests/client-update.test.ts
@@ -35,3 +35,7 @@ test('version update copy no longer claims manual installation or restart', () =
   assert.match(client, /确认后将自动执行更新并重启 dsh web/)
   assert.match(client, /官方更新命令/)
 })
+
+test('client module id matches the scoped npm package name', () => {
+  assert.match(client, /id: "@cocofhu\/anime-find"/)
+})

--- a/src/tests/update-check.test.ts
+++ b/src/tests/update-check.test.ts
@@ -7,7 +7,7 @@ const githubMetadata = {
   currentVersion: '0.1.0',
   installSource: 'github' as const,
   installReference: 'github:cocofhu/anime-find',
-  updateCommand: 'dsh plugin --profile web update anime-find',
+  updateCommand: 'dsh plugin --profile web update @cocofhu/anime-find',
 }
 
 const npmMetadata = {
@@ -36,7 +36,7 @@ test('classifies GitHub, npm and local install references', () => {
   assert.equal(classifyInstallSource('github:cocofhu/anime-find'), 'github')
   assert.equal(classifyInstallSource('^0.1.7'), 'npm')
   assert.equal(classifyInstallSource('0.1.7'), 'npm')
-  assert.equal(classifyInstallSource('https://registry.npmjs.org/anime-find/-/anime-find-0.1.7.tgz'), 'npm')
+  assert.equal(classifyInstallSource('https://registry.npmjs.org/@cocofhu/anime-find/-/cocofhu-anime-find-0.1.9.tgz'), 'npm')
   assert.equal(classifyInstallSource('link:/workspace/anime-find'), 'local')
   assert.equal(classifyInstallSource('file:../anime-find'), 'local')
   assert.equal(classifyInstallSource(undefined), 'unknown')

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -7,6 +7,7 @@ import type { FetchOptions } from './types.js'
 
 const require = createRequire(import.meta.url)
 const REPOSITORY = 'cocofhu/anime-find'
+export const NPM_PACKAGE = '@cocofhu/anime-find'
 export const DEFAULT_PROFILE = process.env.DSH_PROFILE || 'web'
 
 export type InstallSource = 'github' | 'npm' | 'local' | 'unknown'
@@ -43,7 +44,7 @@ export function getVersionMetadata(profile = DEFAULT_PROFILE): VersionMetadata {
     currentVersion,
     installSource,
     ...(installReference ? { installReference } : {}),
-    updateCommand: `dsh plugin --profile ${profile} update anime-find`,
+    updateCommand: `dsh plugin --profile ${profile} update ${NPM_PACKAGE}`,
   }
 }
 
@@ -108,7 +109,7 @@ function readInstallReference(profile: string): string | undefined {
   if (!existsSync(path)) return undefined
   try {
     const pkg = JSON.parse(readFileSync(path, 'utf8')) as PackageJson
-    const value = pkg.dependencies?.['anime-find']
+    const value = pkg.dependencies?.[NPM_PACKAGE] ?? pkg.dependencies?.['anime-find']
     return typeof value === 'string' ? value : undefined
   } catch {
     return undefined


### PR DESCRIPTION
## 改动说明

把 npm 包名改成 \`@cocofhu/anime-find\`，与 SkillHub 统一。同时改：

- \`cordis.patch.yml\` 的 \`name\`（Node import）
- 客户端 \`__ModuleLoader__.load\` 的 \`id\`
- 官方更新命令

Cordis 插件 \`id\` / settings 命名空间仍是 \`anime-find\`。

旧包名 \`anime-find\` 发布后会 deprecate，指向新包。

## 改动类型

- [x] 破坏性变更

## 验证

- [x] \`pnpm test\`
- [ ] CI 通过

## 安全与隐私

- [x] 未包含密钥、Cookie、个人数据、私有网络信息或本地配置


Made with [Cursor](https://cursor.com)