### PR TITLE
Bump version to 0.1.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocofhu/anime-find",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "DeepSeek Harness 插件：对话内多源搜番，卡片详情、磁力复制与规则流媒体在线播放",
   "homepage": "https://github.com/cocofhu/anime-find#readme",
   "bugs": {


### PR DESCRIPTION
## 改动说明

将版本升至 \`0.1.10\`，用 Trusted Publishing 自动发 npm，避开 \`v0.1.9\` 已用 token 发布导致的重复版本失败。

## 改动类型

- [x] 测试或文档

## 验证

- [ ] CI 通过
- [ ] 合并后打 \`v0.1.10\`，确认 Actions Publish 成功

## 安全与隐私

- [x] 未包含密钥、Cookie、个人数据、私有网络信息或本地配置


Made with [Cursor](https://cursor.com)