### PR TITLE
修复：会话回放时搜索卡片封面全部空白

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -3,7 +3,7 @@ window.__ModuleLoader__.load({
   factory: (require) => {
     const React = require("react");
     const h = React.createElement;
-    const { useEffect, useMemo, useState } = React;
+    const { useEffect, useMemo, useRef, useState } = React;
 
     const CSS = `
 .af-root{font-family:inherit;color:var(--dsw-alias-label-primary);max-width:920px}
@@ -265,6 +265,20 @@ window.__ModuleLoader__.load({
       const body = await res.json().catch(() => ({}));
       if (!res.ok || body.ok === false) throw new Error(body.error || "HTTP " + res.status);
       return body;
+    }
+
+    // 会话回放时每个搜索块都要重查一次封面；相同参数的请求必须共享同一个
+    // Promise，否则并发的搜索会占满浏览器对同源的 6 条连接，封面图排不上队。
+    const hydrateSearchCache = new Map();
+    function hydrateSearch(payload) {
+      const key = JSON.stringify(payload);
+      let pending = hydrateSearchCache.get(key);
+      if (!pending) {
+        pending = api("search", payload);
+        hydrateSearchCache.set(key, pending);
+        pending.catch(() => hydrateSearchCache.delete(key));
+      }
+      return pending;
     }
 
     async function copyText(text) {
@@ -948,6 +962,7 @@ window.__ModuleLoader__.load({
       const fromTool = Array.isArray(payload?.items) && payload.items.length ? payload.items : null;
       const running = !!(props?.block && !("kind" in props.block));
       const [fetched, setFetched] = useState(null);
+      const [hydrated, setHydrated] = useState(null);
       const [err, setErr] = useState("");
       const [tab, setTab] = useState("resources");
       const { session, pendingId, openItem, prefetch, close } = useOpenDetail();
@@ -959,7 +974,46 @@ window.__ModuleLoader__.load({
           .catch((e) => { if (live) { setFetched([]); setErr(e.message || String(e)); } });
         return () => { live = false; };
       }, [query, running, !!fromTool]);
-      const items = fromTool || fetched || [];
+      // 回放时 presentationMeta 不会随会话持久化，items 从工具文本反解析而来，
+      // 没有 cover 字段；用同参数重查一次补齐封面。pickPayload 每次渲染都会
+      // 生成新的对象，effect 必须依赖内容 key 而不是对象引用，否则合并结果
+      // 触发重渲染后 effect 会再次执行，搜索请求无限循环。
+      const fromToolKey = fromTool ? fromTool.map((item) => item && item.id).join(",") : "";
+      const hydratedFor = useRef("");
+      useEffect(() => {
+        const source = fromTool;
+        const missing = source?.filter((item) => item && !item.cover && item.id) || [];
+        if (!source?.length || !missing.length || running) {
+          setHydrated(null);
+          return () => {};
+        }
+        const key = query + "|" + (args.offset || 0) + "|" + fromToolKey;
+        if (hydratedFor.current === key) return () => {};
+        hydratedFor.current = key;
+        let live = true;
+        const merge = (rows) => {
+          const byId = new Map((rows || []).filter((row) => row?.id).map((row) => [String(row.id), row]));
+          const byTitle = new Map((rows || []).filter((row) => row?.title).map((row) => [String(row.title).trim().toLowerCase(), row]));
+          const merged = source.map((item) => {
+            const hit = byId.get(String(item.id)) || byTitle.get(String(item.title || "").trim().toLowerCase());
+            return hit?.cover && !item.cover ? { ...hit, ...item, cover: hit.cover } : item;
+          });
+          if (live) setHydrated(merged);
+        };
+        if (query.length >= 2) {
+          const requestedLimit = Number(args.limit);
+          const limit = Number.isFinite(requestedLimit) && requestedLimit > 0
+            ? Math.max(missing.length, Math.min(80, Math.floor(requestedLimit)))
+            : Math.max(12, missing.length);
+          const offset = Math.max(0, Math.floor(Number(args.offset) || 0));
+          hydrateSearch({ query, limit, offset }).then((data) => merge(data.items || []), () => merge([]));
+        } else {
+          Promise.all(missing.map((item) => api("detail", { id: item.id, title: item.title }).catch(() => null)))
+            .then((rows) => merge(rows));
+        }
+        return () => { live = false; };
+      }, [query, running, fromToolKey, args.limit, args.offset]);
+      const items = hydrated || fromTool || fetched || [];
       if (running || !items.length) return err ? h("div", { className: "af-err" }, err) : null;
       return h("div", { className: "af-root af-tool" },
         h("div", { className: "af-search-tabs", role: "tablist" },

--- a/src/tests/client-cover-hydration.test.ts
+++ b/src/tests/client-cover-hydration.test.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const client = readFileSync(new URL('../client.js', import.meta.url), 'utf8')
+
+test('replayed search blocks hydrate missing covers from the search API', () => {
+  assert.match(client, /const \[hydrated, setHydrated\] = useState\(null\)/)
+  assert.match(client, /!item\.cover && item\.id/)
+  assert.match(client, /hydrateSearch\(\{ query, limit, offset \}\)/)
+  assert.match(client, /const items = hydrated \|\| fromTool \|\| fetched \|\| \[\]/)
+})
+
+test('cover hydration keys off block content, never object identity', () => {
+  // pickPayload 每次渲染都会生成新的 items 数组；如果 effect 依赖对象引用，
+  // 合并结果触发的重渲染会让 effect 再次执行，搜索请求无限循环。
+  assert.match(client, /\[query, running, fromToolKey, args\.limit, args\.offset\]/)
+  assert.doesNotMatch(client, /\[query, running, fromTool, args\.limit, args\.offset\]/)
+  assert.match(client, /const hydratedFor = useRef\(""\)/)
+  assert.match(client, /if \(hydratedFor\.current === key\) return/)
+})
+
+test('identical hydration searches share one in-flight request', () => {
+  assert.match(client, /const hydrateSearchCache = new Map\(\)/)
+  assert.match(client, /hydrateSearchCache\.set\(key, pending\)/)
+  assert.match(client, /pending\.catch\(\(\) => hydrateSearchCache\.delete\(key\)\)/)
+})


### PR DESCRIPTION
## 现象

在 DSH Desktop 里重新打开一个包含搜番结果的会话时，所有卡片的封面都是空白占位符（评分、标签正常）。实测一个含 130 张卡片的会话，封面加载成功数为 0。

## 根因

会话回放时 `presentationMeta` 不随会话持久化，`SearchToolView` 拿到的 items 是 `parseRenderedSearch` 从工具渲染文本反解析出来的，只有标题 / 评分 / 来源 / id，**没有 `cover` 字段**。当前 main 分支没有任何补封面的途径，`bangumiCard` 也不返回 cover，所以回放场景封面必然空白。

## 方案

给 `SearchToolView` 增加一次性的封面补水（hydration）：发现有缺 cover 的 items 时，用相同的 query/limit/offset 重查一次搜索，把返回结果按 id / 标题合并回卡片，只填补缺失的 cover。

实现上有两个必须注意的点（也是本 PR 测试重点锁定的行为）：

1. **effect 必须依赖内容 key，不能依赖对象引用。** `pickPayload` 每次渲染都会新建 items 数组，如果 hydration effect 直接把 `fromTool` 放进依赖数组，合并结果触发重渲染后 effect 会再次执行，搜索请求会无限循环。我在本机含 130 张卡片的会话里实测过这种错误写法：几分钟内产生 170+ 个完成的搜索 POST 且持续增长，把浏览器对同源的 6 条并发连接全部占满，封面图片请求永远排不上队（加载成功数恒为 0），同时也在反复轰炸 Mikan / AniBT 上游。因此依赖数组用 `fromToolKey`（item ids 拼接的稳定字符串），并用 `useRef` 保证同一块内容只补一次。
2. **相同参数的补水搜索必须共享同一个 in-flight Promise。** 回放的会话往往有多个搜索块（本季 + 追加分页），它们几乎同时挂载；不去重的话每块各发一个 5~20s 的上游搜索，同样会饿死封面图片请求。失败的 Promise 会从缓存中移除，刷新页面可重试。

修复后同一会话实测：111 张能匹配到封面的卡片全部加载成功，0 失败，请求数稳定不再增长。

## 测试

- 新增 `src/tests/client-cover-hydration.test.ts`（沿用 client-update.test.ts 的源码断言风格），锁定：补水逻辑存在、依赖数组不含对象引用、useRef 防重、in-flight 请求共享。
- `pnpm test`：78 pass / 0 fail；`pnpm typecheck` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)