### PR TITLE
Persist search card covers for session replay

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -742,10 +742,16 @@ window.__ModuleLoader__.load({
       return "";
     }
 
+    function httpCoverUrl(value) {
+      const url = String(value || "").trim();
+      return /^https?:\/\/\S+$/i.test(url) ? url : undefined;
+    }
+
+    // Keep the item regex in sync with SEARCH_ITEM_RE in src/search-text.ts.
     function parseRenderedSearch(text) {
       if (!text || typeof text !== "string") return null;
       const items = [];
-      const re = /^\d+\.\s+(.+?)(?:\s+★([\d.]+))?\s+\[([^\]]+)\]\s*\n\s+id:\s+(\S+)/gm;
+      const re = /^\d+\.\s+(.+?)(?:\s+★([\d.]+))?\s+\[([^\]]+)\]\s*\n\s+id:\s+(\S+)(?:\s*\n\s+cover:\s+(\S+))?/gm;
       let m;
       while ((m = re.exec(text))) {
         items.push({
@@ -753,6 +759,7 @@ window.__ModuleLoader__.load({
           title: m[1].trim(),
           score: m[2] ? Number(m[2]) : undefined,
           sources: m[3].split(/[+/,]/).map((s) => s.trim()).filter(Boolean),
+          cover: httpCoverUrl(m[5]),
         });
       }
       return items.length ? { kind: "anime-find-search", items } : null;

--- a/src/host.ts
+++ b/src/host.ts
@@ -9,6 +9,7 @@ import { assignConfig, DEFAULT_STREAM_RULES, publicConfig, readOverlay, sanitize
 import { enrichCardsWithBangumi, loadBangumiMeta } from './bangumi.js'
 import { fetchBytes } from './http.js'
 import { detailAnime, isSeasonBrowse, searchAnime } from './search.js'
+import { formatSearchItem } from './search-text.js'
 import { parseSeasonHint } from './season.js'
 import { aggregateStreams, fetchAllowedStream, isAllowedStreamUrl, resolveStream, validateRule } from './streaming.js'
 import type { PluginConfig, SearchResult, SourceId, AnimeCard, StreamEpisode, StreamSource } from './types.js'
@@ -150,10 +151,7 @@ function renderSearch(result: SearchResult): string {
     const err = result.errors?.map((e) => `${e.source}: ${e.message}`).join('; ')
     return err ? `没有结果。来源错误：${err}` : '没有找到相关番剧。'
   }
-  const lines = result.items.map((it, i) => {
-    const score = it.score != null ? ` ★${it.score.toFixed(1)}` : ''
-    return `${i + 1}. ${it.title}${score} [${it.sources.join('+')}]\n   id: ${it.id}`
-  })
+  const lines = result.items.map((it, i) => formatSearchItem(i + 1, it))
   const err = result.errors?.length ? `\n部分来源失败：${result.errors.map((e) => e.source).join(', ')}` : ''
   const seasonNote = /[春夏秋冬]$/.test(result.query) ? `（${result.query}）` : ''
   const start = result.offset || 0

--- a/src/search-text.ts
+++ b/src/search-text.ts
@@ -1,0 +1,42 @@
+export interface RenderedSearchItem {
+  id: string
+  title: string
+  score?: number
+  sources: string[]
+  cover?: string
+}
+
+/** Keep in sync with parseRenderedSearch in src/client.js. */
+export const SEARCH_ITEM_RE = /^\d+\.\s+(.+?)(?:\s+★([\d.]+))?\s+\[([^\]]+)\]\s*\n\s+id:\s+(\S+)(?:\s*\n\s+cover:\s+(\S+))?/gm
+
+export function httpCoverUrl(value: string | undefined): string | undefined {
+  const url = String(value || '').trim()
+  return /^https?:\/\/\S+$/i.test(url) ? url : undefined
+}
+
+export function formatSearchItem(
+  index: number,
+  item: { title: string; score?: number; sources: string[]; id: string; cover?: string },
+): string {
+  const score = item.score != null ? ` ★${item.score.toFixed(1)}` : ''
+  const cover = httpCoverUrl(item.cover)
+  const coverLine = cover ? `\n   cover: ${cover}` : ''
+  return `${index}. ${item.title}${score} [${item.sources.join('+')}]\n   id: ${item.id}${coverLine}`
+}
+
+export function parseRenderedSearch(text: string): { kind: 'anime-find-search'; items: RenderedSearchItem[] } | null {
+  if (!text) return null
+  const items: RenderedSearchItem[] = []
+  const re = new RegExp(SEARCH_ITEM_RE.source, SEARCH_ITEM_RE.flags)
+  let match: RegExpExecArray | null
+  while ((match = re.exec(text))) {
+    items.push({
+      id: match[4],
+      title: match[1].trim(),
+      score: match[2] ? Number(match[2]) : undefined,
+      sources: match[3].split(/[+/,]/).map((source) => source.trim()).filter(Boolean),
+      cover: httpCoverUrl(match[5]),
+    })
+  }
+  return items.length ? { kind: 'anime-find-search', items } : null
+}

--- a/src/tests/search-text.test.ts
+++ b/src/tests/search-text.test.ts
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import { formatSearchItem, httpCoverUrl, parseRenderedSearch, SEARCH_ITEM_RE } from '../search-text.js'
+
+const client = readFileSync(new URL('../client.js', import.meta.url), 'utf8')
+const host = readFileSync(new URL('../host.js', import.meta.url), 'utf8')
+
+test('formatSearchItem writes cover URLs for replay, never magnets', () => {
+  const withCover = formatSearchItem(1, {
+    title: '无职转生 第三季',
+    score: 7.9,
+    sources: ['mikan', 'anibt'],
+    id: 'mikan:3060',
+    cover: 'https://mikanani.me/images/Bangumi/s2.jpg',
+  })
+  assert.equal(
+    withCover,
+    '1. 无职转生 第三季 ★7.9 [mikan+anibt]\n   id: mikan:3060\n   cover: https://mikanani.me/images/Bangumi/s2.jpg',
+  )
+  assert.doesNotMatch(withCover, /magnet:/)
+
+  const withoutCover = formatSearchItem(2, {
+    title: '凡人修仙传',
+    sources: ['mikan'],
+    id: 'mikan:1234',
+    cover: 'magnet:?xt=urn:btih:abc',
+  })
+  assert.equal(withoutCover, '2. 凡人修仙传 [mikan]\n   id: mikan:1234')
+})
+
+test('parseRenderedSearch round-trips covers and still reads old sessions', () => {
+  const rendered = [
+    formatSearchItem(1, {
+      title: '无职转生 第三季',
+      score: 7.9,
+      sources: ['mikan'],
+      id: 'mikan:3060',
+      cover: 'https://mikanani.me/images/Bangumi/s2.jpg?x=1',
+    }),
+    '2. 旧会话卡片 ★8.0 [mikan]\n   id: mikan:1234',
+  ].join('\n')
+
+  const parsed = parseRenderedSearch(`找到 2 条，已显示为可点击卡片。\n\n${rendered}`)
+  assert.ok(parsed)
+  assert.equal(parsed.items.length, 2)
+  assert.equal(parsed.items[0].id, 'mikan:3060')
+  assert.equal(parsed.items[0].cover, 'https://mikanani.me/images/Bangumi/s2.jpg?x=1')
+  assert.equal(parsed.items[1].id, 'mikan:1234')
+  assert.equal(parsed.items[1].cover, undefined)
+  assert.equal(parsed.items[1].score, 8)
+})
+
+test('httpCoverUrl only accepts http(s) URLs', () => {
+  assert.equal(httpCoverUrl('https://mikanani.me/a.jpg'), 'https://mikanani.me/a.jpg')
+  assert.equal(httpCoverUrl('http://cdn.example/a.jpg'), 'http://cdn.example/a.jpg')
+  assert.equal(httpCoverUrl('magnet:?xt=urn:btih:abc'), undefined)
+  assert.equal(httpCoverUrl('javascript:alert(1)'), undefined)
+  assert.equal(httpCoverUrl(''), undefined)
+})
+
+test('client parser stays aligned with the shared search-text regex', () => {
+  assert.match(host, /formatSearchItem\(/)
+  assert.equal(client.includes(SEARCH_ITEM_RE.source), true)
+  assert.match(client, /cover: httpCoverUrl\(m\[5\]\)/)
+})


### PR DESCRIPTION
## 改动说明

会话回放时 `presentationMeta` 不会落盘，卡片只能从工具正文反解析。正文里原先只有标题 / 评分 / 来源 / id，没有封面，所以回放封面全是空白占位符。

这次把 http(s) 封面 URL 写进 `renderSearch`，`parseRenderedSearch` 读回来，继续走现有的 `/anime-find/cover` 代理。回放不再打上游搜索，也不依赖本季榜单是否还对得上。磁力链和非法 URL 不会写入正文。旧会话没有 `cover:` 行时仍按原格式解析（封面会空，直到重新搜索）。

这是相对 #34 的主路径修复：#34 用再搜一遍补封面，这里把 URL 留在可持久化数据里。

## 改动类型

- [x] Bug 修复
- [ ] 新功能或来源
- [ ] UI / 交互调整
- [ ] 重构
- [ ] 测试或文档

## 验证

- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] 已在 Harness Web 中手动验证（如适用）
- [ ] UI 改动已附截图（如适用）

## 安全与隐私

- [x] 未包含密钥、Cookie、个人数据、私有网络信息或本地配置
- [x] 新增网络请求设置了超时，并能处理来源失败

## 关联 Issue

Supersedes #34


Made with [Cursor](https://cursor.com)