### PR TITLE
Register settings plugin card with both id and key

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ DSH_HOME="$DSH_HOME" npx @deepseek-ai/dsh plugin --profile web add /absolute/pat
 
 - **页面停在 Loading plugins**：确认 `pnpm build` 成功，重启 `dsh web` 后强制刷新
 - **`ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED`**：改用 npm 安装 `dsh plugin --profile web add @cocofhu/anime-find`，不要走 git 源或旧包名 `anime-find`
-- **loader 报 `requires options.key`**：当前 Harness 把 `settings.plugin.item` 当作 keyed slot，客户端必须用 `key` 而不是 `id` 注册；Host 还需 `settings.register('anime-find', …)` 才能分发配置卡
+- **loader 报 `requires options.id` 或 `requires options.key`**：`settings.plugin.item` 在部分 Harness 版本是 list slot（要 `id`），在 rc7 起是 keyed slot（要 `key`）。客户端必须同时注册 `id` 和 `key`；Host 还需 `settings.register('anime-find', …)` 才能分发配置卡
 - **搜番卡片未出现**：开启新对话，并确认 `anime_find_search` 已加载
 - **本季结果较少**：提高结果上限，或在设置中启用 AniBT / AnimeGarden
 - **来源请求失败**：检查网络与对应站点地址；单个来源失败不会阻止其他来源返回结果

--- a/src/client.js
+++ b/src/client.js
@@ -1376,8 +1376,9 @@ window.__ModuleLoader__.load({
         { name: "tool.call.toolview", key: "anime_find_detail" },
         DetailToolView,
       ));
+      // list slot wants id (older DSH); keyed slot wants key (rc7+). Register both.
       slots.inject("settings.plugin.item", () => slots.register(
-        { name: "settings.plugin.item", key: "anime-find", order: 30 },
+        { name: "settings.plugin.item", id: "anime-find", key: "anime-find", order: 30 },
         ConfigCard,
       ));
     }

--- a/src/tests/client-update.test.ts
+++ b/src/tests/client-update.test.ts
@@ -39,3 +39,7 @@ test('version update copy no longer claims manual installation or restart', () =
 test('client module id matches the scoped npm package name', () => {
   assert.match(client, /id: "@cocofhu\/anime-find"/)
 })
+
+test('settings plugin card registers both list-slot id and keyed-slot key', () => {
+  assert.match(client, /name: "settings\.plugin\.item", id: "anime-find", key: "anime-find"/)
+})


### PR DESCRIPTION
## 改动说明

`settings.plugin.item` 在部分 Harness 上是 list slot（要 `id`），在 rc7 起是 keyed slot（要 `key`）。`0.1.11` 只注册了 `key`，旧 DSH 会在启动时报 `list slot "settings.plugin.item" requires options.id`（#33）。

这次按社区插件的做法同时注册 `id` 和 `key`，不要只改回 `id`，否则新 DSH 会再报 `requires options.key`。

## 改动类型

- [x] Bug 修复
- [ ] 新功能或来源
- [ ] UI / 交互调整
- [ ] 重构
- [x] 测试或文档

## 验证

- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] 已在 Harness Web 中手动验证（如适用）
- [ ] UI 改动已附截图（如适用）

本地 `@deepseek-ai/dsh@0.1.0-rc.7`：重启 `dsh web` 后无 loader 报错，设置 → 插件里能看到「搜番」配置卡。旧 list-slot Harness 这边没有对应版本，靠注册字段覆盖两种检查。

## 安全与隐私

- [x] 未包含密钥、Cookie、个人数据、私有网络信息或本地配置
- [x] 新增网络请求设置了超时，并能处理来源失败

## 关联 Issue

Closes #33


Made with [Cursor](https://cursor.com)