### PR TITLE
Persist anime-find config through ctx.settings instead of overlay json.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ dsh plugin --profile web add /absolute/path/to/anime-find
 - **搜索结果上限**：每批返回的卡片数量
 - **站点地址**：各来源的服务地址，可按需替换镜像
 
-保存后立即生效。配置会写入 Harness 用户目录下的 `anime-find.json`。
-版本与安装来源为只读信息，不会写入该配置文件。
+保存后立即生效。用户配置落在 Harness 用户目录 `$DSH_HOME/settings.yaml` 的 `anime-find:` 段（由 dsh 设置服务原子写入）。版本与安装来源为只读信息，不会写入该段。
+从旧版升级时，若仍存在 `$DSH_HOME/anime-find.json` 且 yaml 中尚无该用户段，插件会把 json 导入 `anime-find:` 后将原文件改名为 `anime-find.json.bak`；若 yaml 里已有用户配置则跳过导入，仍只改名备份，之后不再读取 json。
 
 ### 流媒体播放
 
@@ -188,7 +188,7 @@ DSH_HOME="$DSH_HOME" npx @deepseek-ai/dsh plugin --profile web add /absolute/pat
 
 - **页面停在 Loading plugins**：确认 `pnpm build` 成功，重启 `dsh web` 后强制刷新
 - **`ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED`**：改用 npm 安装 `dsh plugin --profile web add @cocofhu/anime-find`，不要走 git 源或旧包名 `anime-find`
-- **loader 报 `requires options.key`**：当前 Harness 把 `settings.plugin.item` 当作 keyed slot，客户端必须用 `key` 而不是 `id` 注册；Host 还需 `settings.register('anime-find', …)` 才能分发配置卡
+- **loader 报 `requires options.key`**：当前 Harness 把 `settings.plugin.item` 当作 keyed slot，客户端必须用 `key` 而不是 `id` 注册；Host 通过 `installSettingsSection` 登记 `anime-find` 命名空间后才会分发配置卡
 - **搜番卡片未出现**：开启新对话，并确认 `anime_find_search` 已加载
 - **本季结果较少**：提高结果上限，或在设置中启用 AniBT / AnimeGarden
 - **来源请求失败**：检查网络与对应站点地址；单个来源失败不会阻止其他来源返回结果

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   },
   "peerDependencies": {
     "@deepseek-ai/cordis": "*",
+    "@deepseek-ai/dsh-settings": "*",
     "@deepseek-ai/dsh-tools": "*",
     "@deepseek-ai/schemastery": "*",
     "react": "^18.2.0"
@@ -70,6 +71,7 @@
   },
   "devDependencies": {
     "@deepseek-ai/cordis": "^4.0.1",
+    "@deepseek-ai/dsh-settings": "0.1.0-rc.8",
     "@deepseek-ai/dsh-tools": "^0.1.0-rc.6",
     "@deepseek-ai/schemastery": "^3.18.1",
     "@types/node": "^26.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,9 +24,12 @@ importers:
       '@deepseek-ai/cordis':
         specifier: ^4.0.1
         version: 4.0.1
+      '@deepseek-ai/dsh-settings':
+        specifier: 0.1.0-rc.8
+        version: 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)
       '@deepseek-ai/dsh-tools':
         specifier: ^0.1.0-rc.6
-        version: 0.1.0-rc.6(f8724372086ccc1457fc84e7becee2e0)
+        version: 0.1.0-rc.6(269e552b2007f38e53bb961d0d7c2061)
       '@deepseek-ai/schemastery':
         specifier: ^3.18.1
         version: 3.18.1
@@ -72,11 +75,11 @@ packages:
       '@deepseek-ai/dsh-brand': ^0.1.0-rc.6
       '@deepseek-ai/dsh-invariants': ^0.1.0-rc.6
 
-  '@deepseek-ai/dsh-brand@0.1.0-rc.6':
-    resolution: {integrity: sha512-E8j9Nby24qP4rfrdcfc7bpt1CHpGT3tYmycOJJkEOH4ptIdT1m2ro9nmnSd5CWYukTr64A77vjm2WGqHRI92UA==}
+  '@deepseek-ai/dsh-brand@0.1.0-rc.8':
+    resolution: {integrity: sha512-402aUAfHxIZJrArBV4gDf0I/A/69A/By26FX6HTIOyFmCnB4wUBKh8jnglz1CorKWdZy8AKldAhh8HQhQEbGOQ==}
     peerDependencies:
       '@deepseek-ai/cordis': ^4.0.1
-      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.8
 
   '@deepseek-ai/dsh-code-runtime@0.1.0-rc.6':
     resolution: {integrity: sha512-aw8D4IOeMo11A3uxQeE4LFoW3bvaQnVkGFqqtS+lsINDARrOCJHXLUgecoKpys+Lc5erZZ4UQDnymJmL4OCcKA==}
@@ -84,8 +87,8 @@ packages:
       '@deepseek-ai/cordis': ^4.0.1
       '@deepseek-ai/dsh-invariants': ^0.1.0-rc.6
 
-  '@deepseek-ai/dsh-invariants@0.1.0-rc.6':
-    resolution: {integrity: sha512-WfEfOi99a4cpOugRAHTBSTnesLieu3ist1q9PXDXFBHX++K1rAl9+sB7YrdnbB8LH0UOY532gS9xJUYU6w0SLw==}
+  '@deepseek-ai/dsh-invariants@0.1.0-rc.8':
+    resolution: {integrity: sha512-u0lYqyxOYwfsVnbsfGXZos5vFvA4cqFnBEW3/ezgljNwkYwzeUP/Y5wjPnQjP+ZzBn3CnVeIF6s2N2Vk3iA5mQ==}
     peerDependencies:
       '@deepseek-ai/cordis': ^4.0.1
 
@@ -113,6 +116,14 @@ packages:
       '@deepseek-ai/dsh-llm': ^0.1.0-rc.6
       '@deepseek-ai/dsh-scope': ^0.1.0-rc.6
       '@deepseek-ai/dsh-typert-protocol': ^0.1.0-rc.6
+
+  '@deepseek-ai/dsh-settings@0.1.0-rc.8':
+    resolution: {integrity: sha512-pqbMoiSP+Ieww9/4gcHYXcBCDlno1zYDu2OPq+5xdZ+McnK+5YBtHsiRpnR9cHQxGTH7lkfIv+adkOueQW0utg==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-brand': ^0.1.0-rc.8
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.8
+      '@deepseek-ai/schemastery': ^3.18.1
 
   '@deepseek-ai/dsh-system-prompt@0.1.0-rc.6':
     resolution: {integrity: sha512-E7g+XChh4q4/wX++v56z1pV4SA1Rtz42xkznLPPi9FlXrrzJxwHMOUzBZ9Rz3Y1kLhQ++HJG3ZatmNx3rjFilg==}
@@ -399,101 +410,108 @@ snapshots:
 
   '@deepseek-ai/cosmokit@1.8.2': {}
 
-  '@deepseek-ai/dsh-agent@0.1.0-rc.6(b0514d7a320728b6d8f5a31eb3960e10)':
+  '@deepseek-ai/dsh-agent@0.1.0-rc.6(226f41015e98c399b90c92015ce6073b)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1
-      '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))
-      '@deepseek-ai/dsh-scope': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-session': 0.1.0-rc.6(6fd26f59436a18b115f326d6060415e6)
-      '@deepseek-ai/dsh-system-prompt': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))
-      '@deepseek-ai/dsh-typert-protocol': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-scope': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-session': 0.1.0-rc.6(9395b0dd4b247927841ceafbe1a491b6)
+      '@deepseek-ai/dsh-system-prompt': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-typert-protocol': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))
 
-  '@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))':
+  '@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1
-      '@deepseek-ai/dsh-brand': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-brand': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))':
+  '@deepseek-ai/dsh-brand@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1
-      '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-code-runtime@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))':
+  '@deepseek-ai/dsh-code-runtime@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1
-      '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)':
+  '@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1
       '@deepseek-ai/schemastery': 3.18.1
 
-  '@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))':
+  '@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1
-      '@deepseek-ai/dsh-attachment': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-brand': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-timeout': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-attachment': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-brand': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-timeout': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/schemastery': 3.18.1
 
-  '@deepseek-ai/dsh-scope@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))':
+  '@deepseek-ai/dsh-scope@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1
-      '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-session@0.1.0-rc.6(6fd26f59436a18b115f326d6060415e6)':
+  '@deepseek-ai/dsh-session@0.1.0-rc.6(9395b0dd4b247927841ceafbe1a491b6)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1
-      '@deepseek-ai/dsh-brand': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))
-      '@deepseek-ai/dsh-scope': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-typert-protocol': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-brand': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-scope': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-typert-protocol': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))
 
-  '@deepseek-ai/dsh-system-prompt@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))':
+  '@deepseek-ai/dsh-settings@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1
-      '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))
-      '@deepseek-ai/dsh-scope': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-brand': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/schemastery': 3.18.1
 
-  '@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))':
+  '@deepseek-ai/dsh-system-prompt@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1
-      '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
-
-  '@deepseek-ai/dsh-tools@0.1.0-rc.6(f8724372086ccc1457fc84e7becee2e0)':
-    dependencies:
-      '@deepseek-ai/cordis': 4.0.1
-      '@deepseek-ai/dsh-agent': 0.1.0-rc.6(b0514d7a320728b6d8f5a31eb3960e10)
-      '@deepseek-ai/dsh-code-runtime': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))
-      '@deepseek-ai/dsh-scope': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-session': 0.1.0-rc.6(6fd26f59436a18b115f326d6060415e6)
-      '@deepseek-ai/dsh-system-prompt': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))
-      '@deepseek-ai/dsh-user-approval': 0.1.0-rc.6(dbdaba06c174c5e30e3a58edf3cc27a9)
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-scope': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/schemastery': 3.18.1
 
-  '@deepseek-ai/dsh-typert-protocol@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))':
+  '@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1
-      '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-user-approval@0.1.0-rc.6(dbdaba06c174c5e30e3a58edf3cc27a9)':
+  '@deepseek-ai/dsh-tools@0.1.0-rc.6(269e552b2007f38e53bb961d0d7c2061)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1
-      '@deepseek-ai/dsh-agent': 0.1.0-rc.6(b0514d7a320728b6d8f5a31eb3960e10)
-      '@deepseek-ai/dsh-brand': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))
-      '@deepseek-ai/dsh-scope': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-session': 0.1.0-rc.6(6fd26f59436a18b115f326d6060415e6)
-      '@deepseek-ai/dsh-system-prompt': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-agent': 0.1.0-rc.6(226f41015e98c399b90c92015ce6073b)
+      '@deepseek-ai/dsh-code-runtime': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-scope': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-session': 0.1.0-rc.6(9395b0dd4b247927841ceafbe1a491b6)
+      '@deepseek-ai/dsh-system-prompt': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-user-approval': 0.1.0-rc.6(154d569094af5b85ed0d3d294022dda9)
+      '@deepseek-ai/schemastery': 3.18.1
+
+  '@deepseek-ai/dsh-typert-protocol@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)
+
+  '@deepseek-ai/dsh-user-approval@0.1.0-rc.6(154d569094af5b85ed0d3d294022dda9)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1
+      '@deepseek-ai/dsh-agent': 0.1.0-rc.6(226f41015e98c399b90c92015ce6073b)
+      '@deepseek-ai/dsh-brand': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-scope': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-session': 0.1.0-rc.6(9395b0dd4b247927841ceafbe1a491b6)
+      '@deepseek-ai/dsh-system-prompt': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/schemastery': 3.18.1
 
   '@deepseek-ai/schemastery@3.18.1':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
+minimumReleaseAgeExclude:
+  - '@deepseek-ai/dsh-brand@0.1.0-rc.8'
+  - '@deepseek-ai/dsh-invariants@0.1.0-rc.8'
+  - '@deepseek-ai/dsh-settings@0.1.0-rc.8'
 # nth-check 2.0.1 ships no ESM entry, so css-select's ESM build resolves its
 # default import to the CJS namespace and throws "getNCheck is not a function"
 # for any :nth-of-type selector. Rules using positional XPath predicates hit

--- a/src/config-store.ts
+++ b/src/config-store.ts
@@ -1,6 +1,6 @@
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, readFileSync, renameSync, unlinkSync } from 'node:fs'
 import { homedir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { join } from 'node:path'
 import { isPrivateOrLocalHost, normalizeMediaHosts } from './streaming.js'
 import type { PluginConfig, SourceId, StreamRule } from './types.js'
 
@@ -34,9 +34,89 @@ export const DEFAULT_STREAM_RULES: StreamRule[] = [
 
 const ALLOWED: SourceId[] = ['mikan', 'anibt', 'garden']
 
+export const ANIME_FIND_SETTINGS_NS = 'anime-find'
+
 export function overlayPath(): string {
   const home = process.env.DSH_HOME || join(homedir(), '.dsh')
   return join(home, 'anime-find.json')
+}
+
+export function overlayBackupPath(): string {
+  return `${overlayPath()}.bak`
+}
+
+export type OverlayMigrationDecision = 'import' | 'skip'
+
+/** True when settings.describe().user is missing or an empty object. */
+export function userSectionIsEmpty(user: unknown): boolean {
+  if (user == null) return true
+  if (typeof user !== 'object' || Array.isArray(user)) return true
+  return Object.keys(user as Record<string, unknown>).length === 0
+}
+
+/**
+ * Decide whether a leftover overlay json should be imported into the settings
+ * user section. Never import a corrupt/empty overlay over yaml; never import
+ * when the user section already has keys (array fields would wholesale-replace).
+ */
+export function decideOverlayMigration(
+  overlay: Partial<PluginConfig> | null,
+  user: unknown,
+): OverlayMigrationDecision {
+  if (overlay == null) return 'skip'
+  if (!userSectionIsEmpty(user)) return 'skip'
+  if (Object.keys(overlay).length === 0) return 'skip'
+  return 'import'
+}
+
+export function loadOverlayForMigration(): { exists: boolean; overlay: Partial<PluginConfig> | null } {
+  try {
+    const text = readFileSync(overlayPath(), 'utf8')
+    try {
+      const raw = JSON.parse(text) as unknown
+      if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+        return { exists: true, overlay: null }
+      }
+      return { exists: true, overlay: sanitizePatch(raw as Record<string, unknown>) }
+    } catch {
+      return { exists: true, overlay: null }
+    }
+  } catch {
+    return { exists: false, overlay: null }
+  }
+}
+
+export function persistableSection(patch: Partial<PluginConfig>): Record<string, unknown> {
+  const { userAgent: _userAgent, ...rest } = patch
+  return rest
+}
+
+export type SettingsMigrateTarget = {
+  describe?: () => Array<{ ns?: unknown; user?: unknown }>
+  replace: (ns: string, section: object) => Promise<unknown>
+}
+
+export async function migrateLegacyOverlay(settings: SettingsMigrateTarget): Promise<'import' | 'skip' | 'absent'> {
+  const loaded = loadOverlayForMigration()
+  if (!loaded.exists) return 'absent'
+  const user = settings.describe?.().find((item) => String(item.ns) === ANIME_FIND_SETTINGS_NS)?.user
+  const decision = decideOverlayMigration(loaded.overlay, user)
+  if (decision === 'import' && loaded.overlay) {
+    await settings.replace(ANIME_FIND_SETTINGS_NS, persistableSection(loaded.overlay))
+  }
+  retireOverlayFile()
+  return decision
+}
+
+export function retireOverlayFile(): void {
+  const src = overlayPath()
+  const dest = overlayBackupPath()
+  try {
+    if (existsSync(dest)) unlinkSync(dest)
+    renameSync(src, dest)
+  } catch {
+    // Overlay may already have been renamed; runtime never depends on it.
+  }
 }
 
 export function sanitizeSources(raw: unknown): SourceId[] {
@@ -73,12 +153,6 @@ export function readOverlay(): Partial<PluginConfig> {
   } catch {
     return {}
   }
-}
-
-export function writeOverlay(cfg: PluginConfig): void {
-  const path = overlayPath()
-  mkdirSync(dirname(path), { recursive: true })
-  writeFileSync(path, `${JSON.stringify(publicConfig(cfg), null, 2)}\n`)
 }
 
 export function sanitizePatch(raw: Record<string, unknown>): Partial<PluginConfig> {

--- a/src/host.ts
+++ b/src/host.ts
@@ -3,9 +3,20 @@ import type { IncomingMessage, ServerResponse } from 'node:http'
 import { Readable } from 'node:stream'
 import { pipeline } from 'node:stream/promises'
 import type { Context } from '@deepseek-ai/cordis'
+import { installSettingsSection, settingsNamespace } from '@deepseek-ai/dsh-settings'
 import { defineTool } from '@deepseek-ai/dsh-tools'
 import Schema from '@deepseek-ai/schemastery'
-import { assignConfig, DEFAULT_STREAM_RULES, publicConfig, readOverlay, sanitizePatch, sanitizeSources, writeOverlay } from './config-store.js'
+import {
+  ANIME_FIND_SETTINGS_NS as SETTINGS_NS_NAME,
+  assignConfig,
+  DEFAULT_STREAM_RULES,
+  migrateLegacyOverlay,
+  publicConfig,
+  readOverlay,
+  sanitizePatch,
+  sanitizeSources,
+  type SettingsMigrateTarget,
+} from './config-store.js'
 import { enrichCardsWithBangumi, loadBangumiMeta } from './bangumi.js'
 import { fetchBytes } from './http.js'
 import { detailAnime, isSeasonBrowse, searchAnime } from './search.js'
@@ -17,6 +28,11 @@ import { applyPluginUpdate } from './apply-update.js'
 
 export const name = 'anime-find'
 export const inject = ['tools']
+export const ANIME_FIND_SETTINGS_NS = settingsNamespace(SETTINGS_NS_NAME)
+
+type SettingsWriter = SettingsMigrateTarget & {
+  replace: (ns: string, section: object) => Promise<unknown>
+}
 
 export interface Config extends PluginConfig {}
 
@@ -32,9 +48,17 @@ export const Config: Schema<Config> = Schema.object({
   streamRules: Schema.array(Schema.object({})).default(DEFAULT_STREAM_RULES).description('流媒体规则（静态 CSS / 受限 XPath / script: 取址；默认含一条试点源）'),
 }) as unknown as Schema<Config>
 
+export function applyResolvedSettings(cfg: PluginConfig, current: () => unknown): void {
+  const snapshot = current()
+  if (!snapshot || typeof snapshot !== 'object') return
+  assignConfig(cfg, sanitizePatch(structuredClone(snapshot) as Record<string, unknown>))
+}
+
 export function apply(ctx: Context, config: Config): void {
   const cfg = withDefaults(config)
   assignConfig(cfg, readOverlay())
+  let current: () => unknown = () => config
+  let settingsWriter: SettingsWriter | undefined
 
   ctx.tools.register(defineTool({
     name: 'anime_find_search',
@@ -96,7 +120,7 @@ export function apply(ctx: Context, config: Config): void {
 
   ctx.inject(['webServer'], (c) => {
     const server = (c as unknown as { webServer: { register: (route: { kind: string; path: string; handler: (req: IncomingMessage, res: ServerResponse) => void | Promise<void> }) => void } }).webServer
-    server.register({ kind: 'exact', path: '/anime-find', handler: (req, res) => handleApi(req, res, cfg) })
+    server.register({ kind: 'exact', path: '/anime-find', handler: (req, res) => handleApi(req, res, cfg, () => settingsWriter) })
     server.register({ kind: 'exact', path: '/anime-find/cover', handler: (req, res) => handleCover(req, res, cfg) })
     server.register({ kind: 'exact', path: '/anime-find/media', handler: (req, res) => handleMedia(req, res, cfg) })
     // DSH only exposes the declared client entry automatically. Serve hls.js explicitly
@@ -104,13 +128,26 @@ export function apply(ctx: Context, config: Config): void {
     server.register({ kind: 'exact', path: '/plugins/anime-find/hls.min.js', handler: (_req, res) => handleHlsAsset(res) })
   })
 
-  // 插件配置页按 Host settings 命名空间分发 settings.plugin.item。
-  // 不登记 anime-find 的话，客户端卡片永远不会被 dispatch。
-  ctx.inject(['settings'], (c) => {
-    const settings = (c as unknown as {
-      settings: { register: (ns: string, schema: typeof Config, options?: { base?: Config }) => void }
-    }).settings
-    settings.register('anime-find', Config, { base: config })
+  installSettingsSection(ctx, ANIME_FIND_SETTINGS_NS, Config, config, {
+    setSource: (source) => {
+      current = source
+    },
+    onChange: () => {
+      applyResolvedSettings(cfg, current)
+    },
+  })
+
+  // Second inject: persist via replace without registering the namespace again.
+  ctx.inject(['settings'], (sctx) => {
+    const settings = (sctx as unknown as { settings: SettingsWriter; effect?: (factory: () => () => void) => void }).settings
+    const effect = (sctx as unknown as { effect?: (factory: () => () => void) => void }).effect
+    settingsWriter = settings
+    if (typeof effect === 'function') {
+      effect(() => () => {
+        if (settingsWriter === settings) settingsWriter = undefined
+      })
+    }
+    void migrateLegacyOverlay(settings)
   })
 }
 
@@ -183,7 +220,12 @@ function sendJson(res: ServerResponse, code: number, body: unknown): void {
   res.end(JSON.stringify(body))
 }
 
-async function handleApi(req: IncomingMessage, res: ServerResponse, cfg: PluginConfig): Promise<void> {
+export async function handleApi(
+  req: IncomingMessage,
+  res: ServerResponse,
+  cfg: PluginConfig,
+  getSettings?: () => SettingsWriter | undefined,
+): Promise<void> {
   try {
     const url = new URL(req.url || '/', 'http://127.0.0.1')
     const body = req.method === 'POST' ? await readBody(req) : {}
@@ -236,8 +278,12 @@ async function handleApi(req: IncomingMessage, res: ServerResponse, cfg: PluginC
     }
     if (method === 'config') {
       if (body.save) {
+        const settings = getSettings?.()
+        if (!settings?.replace) {
+          return sendJson(res, 503, { ok: false, error: 'settings 服务不可用，无法保存配置' })
+        }
         assignConfig(cfg, sanitizePatch(body))
-        writeOverlay(cfg)
+        await settings.replace(SETTINGS_NS_NAME, publicConfig(cfg))
       }
       return sendJson(res, 200, { ok: true, ...publicConfig(cfg), ...getVersionMetadata() })
     }

--- a/src/tests/config-store.test.ts
+++ b/src/tests/config-store.test.ts
@@ -1,0 +1,184 @@
+import assert from 'node:assert/strict'
+import { mkdtempSync, readFileSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test, { describe } from 'node:test'
+import {
+  assignConfig,
+  decideOverlayMigration,
+  DEFAULT_SOURCES,
+  DEFAULT_STREAM_RULES,
+  loadOverlayForMigration,
+  overlayBackupPath,
+  overlayPath,
+  persistableSection,
+  publicConfig,
+  sanitizePatch,
+  sanitizeSources,
+  sanitizeStreamRules,
+  userSectionIsEmpty,
+} from '../config-store.js'
+import type { PluginConfig, StreamRule } from '../types.js'
+
+const live = (): PluginConfig => ({
+  mikanHost: 'https://mikanani.me',
+  anibtHost: 'https://anibt.net',
+  gardenHost: 'https://api.animes.garden',
+  timeoutMs: 20000,
+  userAgent: 'Mozilla/5.0 (compatible; anime-find/0.1)',
+  maxResults: 12,
+  sources: ['mikan'],
+  streamEnabled: true,
+  streamRules: DEFAULT_STREAM_RULES.map((rule) => structuredClone(rule)),
+})
+
+const demoRule: StreamRule = {
+  id: 'demo',
+  name: 'Demo',
+  enabled: true,
+  baseURL: 'https://media.example.test',
+  searchURL: '/search?q={{keyword}}',
+  searchList: '.result',
+  searchName: '.name',
+  searchResult: 'a',
+  chapterRoads: '.episode',
+  chapterResult: 'a',
+}
+
+test('sanitizePatch trims hosts and clamps timeout/maxResults', () => {
+  const patch = sanitizePatch({
+    mikanHost: '  https://mikan.example  ',
+    anibtHost: ' https://anibt.example ',
+    gardenHost: 'https://garden.example',
+    timeoutMs: 999999,
+    maxResults: 1000,
+  })
+  assert.equal(patch.mikanHost, 'https://mikan.example')
+  assert.equal(patch.anibtHost, 'https://anibt.example')
+  assert.equal(patch.gardenHost, 'https://garden.example')
+  assert.equal(patch.timeoutMs, 120000)
+  assert.equal(patch.maxResults, 80)
+})
+
+test('sanitizePatch rejects timeout below 3000 and maxResults below 1', () => {
+  const patch = sanitizePatch({ timeoutMs: 2999, maxResults: 0 })
+  assert.equal(patch.timeoutMs, undefined)
+  assert.equal(patch.maxResults, undefined)
+})
+
+test('sanitizePatch falls back illegal sources and ignores garbage keys', () => {
+  const patch = sanitizePatch({
+    sources: ['not-a-source', 12],
+    junk: true,
+    apiKey: 'secret',
+  } as Record<string, unknown>)
+  assert.deepEqual(patch.sources, DEFAULT_SOURCES)
+  assert.equal('junk' in patch, false)
+  assert.equal('apiKey' in patch, false)
+})
+
+test('sanitizePatch drops private stream rule origins', () => {
+  const patch = sanitizePatch({
+    streamRules: [
+      { ...demoRule, baseURL: 'http://127.0.0.1' },
+      { ...demoRule, id: 'ok' },
+    ],
+  })
+  assert.equal(patch.streamRules?.length, 1)
+  assert.equal(patch.streamRules?.[0].id, 'ok')
+  assert.deepEqual(sanitizeStreamRules([{ ...demoRule, baseURL: 'http://192.168.0.1' }]), [])
+})
+
+test('publicConfig omits userAgent and keeps sources/streamRules', () => {
+  const cfg = live()
+  cfg.sources = ['mikan', 'garden']
+  cfg.streamEnabled = false
+  const pub = publicConfig(cfg)
+  assert.equal('userAgent' in pub, false)
+  assert.deepEqual(pub.sources, ['mikan', 'garden'])
+  assert.equal(pub.streamEnabled, false)
+  assert.ok(Array.isArray(pub.streamRules) && pub.streamRules.length >= 1)
+  assert.equal(pub.timeoutMs, 20000)
+  assert.equal(pub.maxResults, 12)
+})
+
+test('persistableSection strips userAgent from a sanitized overlay', () => {
+  const section = persistableSection(sanitizePatch({
+    sources: ['anibt'],
+    userAgent: 'should-not-persist',
+  }))
+  assert.deepEqual(section.sources, ['anibt'])
+  assert.equal('userAgent' in section, false)
+})
+
+test('assignConfig copies sanitized fields onto the live object', () => {
+  const cfg = live()
+  assignConfig(cfg, sanitizePatch({
+    timeoutMs: 8000,
+    sources: ['garden'],
+    streamEnabled: false,
+  }))
+  assert.equal(cfg.timeoutMs, 8000)
+  assert.deepEqual(cfg.sources, ['garden'])
+  assert.equal(cfg.streamEnabled, false)
+})
+
+test('userSectionIsEmpty treats missing and {} as empty', () => {
+  assert.equal(userSectionIsEmpty(undefined), true)
+  assert.equal(userSectionIsEmpty(null), true)
+  assert.equal(userSectionIsEmpty({}), true)
+  assert.equal(userSectionIsEmpty({ sources: ['mikan'] }), false)
+})
+
+test('decideOverlayMigration: no user + overlay with keys → import', () => {
+  assert.equal(decideOverlayMigration({ sources: ['garden'] }, undefined), 'import')
+  assert.equal(decideOverlayMigration({ streamRules: [demoRule] }, {}), 'import')
+})
+
+test('decideOverlayMigration: user already has keys → skip', () => {
+  assert.equal(decideOverlayMigration({ sources: ['garden'] }, { sources: ['mikan'] }), 'skip')
+  assert.equal(decideOverlayMigration({ timeoutMs: 9000 }, { streamEnabled: true }), 'skip')
+})
+
+test('decideOverlayMigration: corrupt or empty overlay → skip and would not overwrite', () => {
+  assert.equal(decideOverlayMigration(null, undefined), 'skip')
+  assert.equal(decideOverlayMigration({}, undefined), 'skip')
+  assert.equal(decideOverlayMigration(null, { sources: ['mikan'] }), 'skip')
+})
+
+describe('legacy overlay file helpers', { concurrency: false }, () => {
+  const prevHome = process.env.DSH_HOME
+
+  test('loadOverlayForMigration reads a parseable json and reports missing files', (t) => {
+    const dir = mkdtempSync(join(tmpdir(), 'anime-find-overlay-'))
+    t.after(() => {
+      process.env.DSH_HOME = prevHome
+      rmSync(dir, { recursive: true, force: true })
+    })
+    process.env.DSH_HOME = dir
+    assert.deepEqual(loadOverlayForMigration(), { exists: false, overlay: null })
+    writeFileSync(overlayPath(), JSON.stringify({ sources: ['garden'], timeoutMs: 7000 }))
+    const loaded = loadOverlayForMigration()
+    assert.equal(loaded.exists, true)
+    assert.deepEqual(loaded.overlay?.sources, ['garden'])
+    assert.equal(loaded.overlay?.timeoutMs, 7000)
+  })
+
+  test('loadOverlayForMigration treats corrupt json as unimportable', (t) => {
+    const dir = mkdtempSync(join(tmpdir(), 'anime-find-overlay-'))
+    t.after(() => {
+      process.env.DSH_HOME = prevHome
+      rmSync(dir, { recursive: true, force: true })
+    })
+    process.env.DSH_HOME = dir
+    writeFileSync(overlayPath(), '{not json')
+    assert.deepEqual(loadOverlayForMigration(), { exists: true, overlay: null })
+    writeFileSync(overlayPath(), '[]')
+    assert.deepEqual(loadOverlayForMigration(), { exists: true, overlay: null })
+  })
+
+  test('sanitizeSources still matches existing parse tests', () => {
+    assert.deepEqual(sanitizeSources(['mikan', 'garden', 'mikan']), ['mikan', 'garden'])
+    assert.deepEqual(sanitizeSources(['nope']), DEFAULT_SOURCES)
+  })
+})

--- a/src/tests/host-settings.test.ts
+++ b/src/tests/host-settings.test.ts
@@ -1,0 +1,300 @@
+import assert from 'node:assert/strict'
+import { existsSync, readFileSync, writeFileSync, rmSync, mkdtempSync } from 'node:fs'
+import { IncomingMessage, ServerResponse } from 'node:http'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Readable } from 'node:stream'
+import test, { describe } from 'node:test'
+import type { Context } from '@deepseek-ai/cordis'
+import { apply, applyResolvedSettings, handleApi } from '../host.js'
+import {
+  overlayBackupPath,
+  overlayPath,
+  publicConfig,
+  sanitizePatch,
+} from '../config-store.js'
+import type { PluginConfig, StreamRule } from '../types.js'
+
+const rule: StreamRule = {
+  id: 'demo',
+  name: 'Demo',
+  enabled: true,
+  baseURL: 'https://media.example.test',
+  searchURL: '/search?q={{keyword}}',
+  searchList: '.result',
+  searchName: '.name',
+  searchResult: 'a',
+  chapterRoads: '.episode',
+  chapterResult: 'a',
+}
+
+const baseConfig = (): PluginConfig => ({
+  mikanHost: 'https://mikanani.me',
+  anibtHost: 'https://anibt.net',
+  gardenHost: 'https://api.animes.garden',
+  timeoutMs: 20000,
+  userAgent: 'test-agent',
+  maxResults: 12,
+  sources: ['mikan'],
+  streamEnabled: true,
+  streamRules: [rule],
+})
+
+type SettingsMock = {
+  settings: {
+    register: (ns: string, schema: unknown, options?: unknown) => {
+      get: () => unknown
+      watch: (cb: () => void) => () => void
+      replace: (section: object) => Promise<unknown>
+    }
+    describe: () => Array<{ ns: string; user?: unknown }>
+    replace: (ns: string, section: object) => Promise<unknown>
+  }
+  replaces: object[]
+  registers: string[]
+  fireWatch: () => void
+  resolved: PluginConfig
+}
+
+function memorySettings(initial?: { user?: Record<string, unknown>; resolved?: PluginConfig }): SettingsMock {
+  const resolved = initial?.resolved ? structuredClone(initial.resolved) : baseConfig()
+  let user = initial?.user
+  const replaces: object[] = []
+  const registers: string[] = []
+  const watchers: Array<() => void> = []
+  const settings = {
+    register(ns: string) {
+      registers.push(ns)
+      return {
+        get: () => Object.freeze(structuredClone(resolved)),
+        watch(cb: () => void) {
+          watchers.push(cb)
+          return () => {}
+        },
+        replace: (section: object) => settings.replace(ns, section),
+      }
+    },
+    describe() {
+      return [{ ns: 'anime-find', user }]
+    },
+    async replace(_ns: string, section: object) {
+      replaces.push(structuredClone(section))
+      user = section as Record<string, unknown>
+      Object.assign(resolved, section)
+      for (const watcher of watchers) watcher()
+    },
+  }
+  return {
+    settings,
+    replaces,
+    registers,
+    fireWatch: () => {
+      for (const watcher of watchers) watcher()
+    },
+    resolved,
+  }
+}
+
+function createCtx(settings?: SettingsMock['settings']) {
+  const tools: unknown[] = []
+  const routes: Array<{ path: string; handler: (req: IncomingMessage, res: ServerResponse) => void | Promise<void> }> = []
+  const ctx = {
+    fiber: { state: 0 },
+    tools: {
+      register(tool: unknown) {
+        tools.push(tool)
+      },
+    },
+    inject(deps: string[], fn: (scoped: unknown) => void) {
+      if (deps.includes('systemPrompt')) {
+        fn({ systemPrompt: { section() {} } })
+        return
+      }
+      if (deps.includes('webServer')) {
+        fn({
+          webServer: {
+            register(route: { path: string; handler: (req: IncomingMessage, res: ServerResponse) => void | Promise<void> }) {
+              routes.push(route)
+            },
+          },
+        })
+        return
+      }
+      if (deps.includes('settings')) {
+        if (!settings) return
+        fn({
+          settings,
+          effect(factory: () => () => void) {
+            factory()
+          },
+        })
+      }
+    },
+  }
+  return { ctx: ctx as unknown as Context, tools, routes }
+}
+
+function mockReq(body: Record<string, unknown>): IncomingMessage {
+  const stream = Readable.from([JSON.stringify(body)]) as IncomingMessage
+  stream.method = 'POST'
+  stream.url = '/anime-find'
+  return stream
+}
+
+function mockRes(): ServerResponse & { body: string } {
+  const res = {
+    statusCode: 0,
+    body: '',
+    setHeader() {},
+    end(chunk?: unknown) {
+      this.body = typeof chunk === 'string' ? chunk : chunk == null ? '' : String(chunk)
+    },
+  }
+  return res as unknown as ServerResponse & { body: string }
+}
+
+describe('host settings persistence', { concurrency: false }, () => {
+  const prevHome = process.env.DSH_HOME
+
+  test('config save calls settings.replace with publicConfig and does not write json', async (t) => {
+    const dir = mkdtempSync(join(tmpdir(), 'anime-find-host-'))
+    t.after(() => {
+      process.env.DSH_HOME = prevHome
+      rmSync(dir, { recursive: true, force: true })
+    })
+    process.env.DSH_HOME = dir
+    const cfg = baseConfig()
+    const mock = memorySettings({ resolved: cfg })
+    const res = mockRes()
+    await handleApi(mockReq({
+      method: 'config',
+      save: true,
+      sources: ['garden'],
+      timeoutMs: 9000,
+      userAgent: 'should-not-land',
+    }), res, cfg, () => mock.settings)
+    assert.equal(res.statusCode, 200)
+    assert.equal(mock.replaces.length, 1)
+    const payload = mock.replaces[0] as Record<string, unknown>
+    assert.deepEqual(payload.sources, ['garden'])
+    assert.equal(payload.timeoutMs, 9000)
+    assert.equal('userAgent' in payload, false)
+    assert.deepEqual(payload, publicConfig(cfg))
+    assert.equal(existsSync(overlayPath()), false)
+  })
+
+  test('config save fails without settings and does not create json or mutate cfg', async (t) => {
+    const dir = mkdtempSync(join(tmpdir(), 'anime-find-host-'))
+    t.after(() => {
+      process.env.DSH_HOME = prevHome
+      rmSync(dir, { recursive: true, force: true })
+    })
+    process.env.DSH_HOME = dir
+    const cfg = baseConfig()
+    const res = mockRes()
+    await handleApi(mockReq({
+      method: 'config',
+      save: true,
+      sources: ['garden'],
+    }), res, cfg, () => undefined)
+    assert.equal(res.statusCode, 503)
+    assert.match(res.body, /settings 服务不可用/)
+    assert.deepEqual(cfg.sources, ['mikan'])
+    assert.equal(existsSync(overlayPath()), false)
+  })
+
+  test('migrate imports overlay when user section is empty then renames to .bak', async (t) => {
+    const dir = mkdtempSync(join(tmpdir(), 'anime-find-host-'))
+    t.after(() => {
+      process.env.DSH_HOME = prevHome
+      rmSync(dir, { recursive: true, force: true })
+    })
+    process.env.DSH_HOME = dir
+    writeFileSync(overlayPath(), `${JSON.stringify({
+      sources: ['anibt', 'garden'],
+      streamRules: [rule],
+      timeoutMs: 11000,
+    }, null, 2)}\n`)
+    const mock = memorySettings({ user: undefined, resolved: baseConfig() })
+    const { ctx, tools, routes } = createCtx(mock.settings)
+    apply(ctx, baseConfig())
+    await new Promise((resolve) => setImmediate(resolve))
+    assert.equal(mock.registers.length, 1)
+    assert.equal(mock.registers[0], 'anime-find')
+    assert.equal(mock.replaces.length, 1)
+    const payload = mock.replaces[0] as Record<string, unknown>
+    assert.deepEqual(payload.sources, ['anibt', 'garden'])
+    assert.ok(Array.isArray(payload.streamRules))
+    assert.equal(existsSync(overlayPath()), false)
+    assert.equal(existsSync(overlayBackupPath()), true)
+    assert.match(readFileSync(overlayBackupPath(), 'utf8'), /anibt/)
+    const api = routes.find((route) => route.path === '/anime-find')
+    assert.ok(api)
+    const peek = mockRes()
+    await api.handler(mockReq({ method: 'config' }), peek)
+    const live = JSON.parse(peek.body) as { sources: string[]; streamRules: StreamRule[] }
+    assert.deepEqual(live.sources, ['anibt', 'garden'])
+    const toolCount = tools.length
+    mock.resolved.sources = ['garden']
+    mock.resolved.streamRules = [{ ...rule, id: 'after-change' }]
+    mock.fireWatch()
+    assert.equal(tools.length, toolCount)
+    const after = mockRes()
+    await api.handler(mockReq({ method: 'config' }), after)
+    const updated = JSON.parse(after.body) as { sources: string[]; streamRules: StreamRule[] }
+    assert.deepEqual(updated.sources, ['garden'])
+    assert.equal(updated.streamRules[0].id, 'after-change')
+  })
+
+  test('migrate skips when user section exists and still renames json to .bak', async (t) => {
+    const dir = mkdtempSync(join(tmpdir(), 'anime-find-host-'))
+    t.after(() => {
+      process.env.DSH_HOME = prevHome
+      rmSync(dir, { recursive: true, force: true })
+    })
+    process.env.DSH_HOME = dir
+    writeFileSync(overlayPath(), `${JSON.stringify({ sources: ['garden'] })}\n`)
+    const mock = memorySettings({
+      user: { sources: ['mikan'] },
+      resolved: { ...baseConfig(), sources: ['mikan'] },
+    })
+    const { ctx } = createCtx(mock.settings)
+    apply(ctx, baseConfig())
+    await new Promise((resolve) => setImmediate(resolve))
+    assert.equal(mock.replaces.length, 0)
+    assert.equal(existsSync(overlayPath()), false)
+    assert.equal(existsSync(overlayBackupPath()), true)
+  })
+
+  test('onChange copies resolved settings into live cfg and ignores leftover bak', async (t) => {
+    const dir = mkdtempSync(join(tmpdir(), 'anime-find-host-'))
+    t.after(() => {
+      process.env.DSH_HOME = prevHome
+      rmSync(dir, { recursive: true, force: true })
+    })
+    process.env.DSH_HOME = dir
+    writeFileSync(overlayBackupPath(), JSON.stringify({ sources: ['anibt'] }))
+    const cfg = baseConfig()
+    applyResolvedSettings(cfg, () => ({
+      ...baseConfig(),
+      sources: ['garden'],
+      streamRules: [{ ...rule, id: 'from-settings' }],
+    }))
+    assert.deepEqual(cfg.sources, ['garden'])
+    assert.equal(cfg.streamRules[0].id, 'from-settings')
+    const again = sanitizePatch(JSON.parse(readFileSync(overlayBackupPath(), 'utf8')) as Record<string, unknown>)
+    assert.deepEqual(again.sources, ['anibt'])
+    assert.notDeepEqual(cfg.sources, again.sources)
+  })
+
+  test('apply without settings still loads and does not write overlay json', () => {
+    const { ctx, tools } = createCtx()
+    apply(ctx, baseConfig())
+    assert.ok(tools.length >= 1)
+    const cfg = baseConfig()
+    const res = mockRes()
+    return handleApi(mockReq({ method: 'config', save: true, sources: ['garden'] }), res, cfg, () => undefined).then(() => {
+      assert.equal(res.statusCode, 503)
+    })
+  })
+})


### PR DESCRIPTION
Stop dual-writing $DSH_HOME/anime-find.json so user sources and stream rules land in settings.yaml via the official settings namespace, with a one-shot overlay import and .bak rename.

Co-authored-by: Cursor <cursoragent@cursor.com>
