### PR TITLE
Bump version to 0.1.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocofhu/anime-find",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "DeepSeek Harness 插件：对话内多源搜番，卡片详情、磁力复制与规则流媒体在线播放",
   "homepage": "https://github.com/cocofhu/anime-find#readme",
   "bugs": {


### PR DESCRIPTION
## 改动说明

升至 `0.1.12`，包含已合入 main 的设置 yaml 持久化、settings 卡 `id`/`key` 双注册，以及会话回放封面 URL。

## 改动类型

- [x] 测试或文档

## 验证

- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] 已在 Harness Web 中手动验证（如适用）
- [ ] UI 改动已附截图（如适用）

## 安全与隐私

- [x] 未包含密钥、Cookie、个人数据、私有网络信息或本地配置


Made with [Cursor](https://cursor.com)