### PR TITLE
性能：视口外的卡片不再参与每一次重排

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -14,7 +14,11 @@ window.__ModuleLoader__.load({
 .af-mini.primary{background:var(--dsw-alias-button-primary-fill);color:var(--dsw-alias-label-primary-foreground);border-color:transparent}
 .af-week{font-weight:700;font-size:13px;margin:8px 0 6px}
 .af-cards{display:grid;grid-template-columns:1fr;gap:10px}
-.af-card{display:flex;gap:12px;align-items:flex-start;background:var(--dsw-alias-bg-layer-2);border:1px solid var(--dsw-alias-border-l1);border-radius:12px;padding:12px;cursor:pointer;text-align:left;width:100%;font:inherit;color:var(--dsw-alias-label-primary)}
+/* 一次季度搜索会渲染上百张卡片,滚出视口后仍参与每一次布局和栅格化。
+   窗口 resize 和拖动侧边栏会连续触发重排,整条会话被反复重算：130 张卡片实测
+   每次 resize 要 1149ms(浏览器进程满核),跳过视口外卡片后降到 57ms。
+   contain-intrinsic-size 用 auto 记住实测高度,占位值取实测的单卡高度。 */
+.af-card{display:flex;gap:12px;align-items:flex-start;background:var(--dsw-alias-bg-layer-2);border:1px solid var(--dsw-alias-border-l1);border-radius:12px;padding:12px;cursor:pointer;text-align:left;width:100%;font:inherit;color:var(--dsw-alias-label-primary);content-visibility:auto;contain-intrinsic-size:auto 168px}
 .af-card:hover{border-color:var(--dsw-alias-border-l2);background:var(--dsw-alias-interactive-bg-hover)}
 .af-card:focus-visible{outline:2px solid var(--dsw-alias-brand-primary-new-colorprimary-new-color);outline-offset:2px}
 .af-card.busy{cursor:wait}

--- a/src/tests/client-card-rendering.test.ts
+++ b/src/tests/client-card-rendering.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const client = readFileSync(new URL('../client.js', import.meta.url), 'utf8')
+
+test('cards skip rendering work while scrolled out of view', () => {
+  // 视口外的卡片如果仍参与布局/栅格化,窗口 resize 和拖动侧边栏会把整条会话
+  // 反复重算 —— 130 张卡片实测每次 resize 1149ms,加上 content-visibility 后 57ms。
+  assert.match(client, /\.af-card\{[^}]*content-visibility:auto/)
+})
+
+test('card placeholder keeps its measured height so the scrollbar does not jump', () => {
+  // auto 关键字让浏览器记住实测高度;后面的长度只是首次渲染前的占位估值。
+  assert.match(client, /\.af-card\{[^}]*contain-intrinsic-size:auto \d+px/)
+})


### PR DESCRIPTION
## 现象

会话里存在搜番结果时，**拖动窗口边缘改变大小、或拖动侧边栏分隔条，都会非常卡**。会话越长越明显。

## 测量

在一个含 130 张卡片的会话上，用 `SetWindowPos` 连续改变窗口宽度，测每次 resize 的墙钟耗时，同时分进程采样 CPU：

| 状态 | 每次 resize | 主进程 CPU | 渲染进程 | GPU |
|---|---|---|---|---|
| 未打开会话（对照） | 36 ms | — | — | — |
| 打开该会话 | **1149 ms** | **103%**（满核） | 1.8% | 2.3% |
| 同会话，把 `.af-root` 全部 `display:none` | **33 ms** | 57% | — | — |
| 同会话，加上本 PR 的 `content-visibility` | **57 ms** | 82% | 16% | 24% |

渲染侧 rAF 记录同样吻合：修复前 15 次 resize 产生 72 个超过 100 ms 的帧（多数正好卡在 1000 ms），修复后 **0 个超过 50 ms 的帧**。

两点需要说明：

1. **不是 Electron 的问题。** 我用独立 profile 的 Chrome 151 加载同一个服务、打开同一个会话、用完全相同的方法测量，得到 **1206 ms/次**，与 Electron 的 1149 ms 一致；两者的 `SystemInfo.getInfo` GPU 特性状态逐字节相同。所以这是页面自身的渲染成本。
2. **不是图片解码单独造成的。** 把 130 张封面的 `src` 换成 1×1 占位后仍有 689 ms/次，说明卡片本身的布局与栅格化占了大头；`content-visibility` 两者一起解决。

## 方案

给 `.af-card` 加 `content-visibility:auto`，让滚出视口的卡片跳过布局和绘制。

`contain-intrinsic-size` 使用 `auto <length>` 形式：`auto` 让每张卡片渲染过一次后记住实测高度，后面的长度值只是从未渲染过的卡片的占位估值，取实测单卡高度（168px），避免首次滚动时滚动条跳动。

## 验证

- 修复后复测：封面 130/130 正常加载，卡片高度正常（无 0 高度塌陷），点击、悬停、抽屉展开均正常。
- 新增 `src/tests/client-card-rendering.test.ts`，沿用仓库既有的源码断言风格。
- `pnpm test`：102 pass / 0 fail；`pnpm typecheck` 通过。

> 注：本 PR 基于 main，与 #34 互不依赖，可独立合入。

🤖 Generated with [Claude Code](https://claude.com/claude-code)